### PR TITLE
Calling the correct handler removal function for the disposable

### DIFF
--- a/rx.node.js
+++ b/rx.node.js
@@ -90,7 +90,7 @@ Rx.Node = {
             eventEmitter.on(eventName, handler);
 
             return function () {
-                eventEmitter.off(eventName, handler);
+                eventEmitter.removeListener(eventName, handler);
             }
         }).publish().refCount();
     },


### PR DESCRIPTION
The disposable attempts to call the #off() method on the event emitter, crashing node.js. Node.js doesn't have an #off() method on it's EventEmitter class, it only has a #removeListener() function.

http://nodejs.org/api/events.html#events_emitter_removelistener_event_listener
https://github.com/joyent/node/blob/master/lib/events.js
