### PR TITLE
Fixed the loading order for node.js

### DIFF
--- a/rx.node.js
+++ b/rx.node.js
@@ -4,9 +4,9 @@ require('./rx.binding');
 require('./rx.coincidence');
 require('./rx.experimental');
 require('./rx.joinpatterns');
-require('./rx.testing');
 require('./rx.time');
 require('./rx.virtualtime');
+require('./rx.testing');
 
 // Add specific Node functions
 var EventEmitter = require('events').EventEmitter,


### PR DESCRIPTION
When loading master in a node.js environment. You currently get the following exception:

```
/Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.js:254
        __.prototype = parent.prototype;
                             ^
TypeError: Cannot read property 'prototype' of undefined
    at inherits.inherits.Rx.Internals.inherits (/Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.js:254:30)
    at /Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.testing.js:362:9
    at /Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.testing.js:491:7
    at Observer (/Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.testing.js:18:26)
    at Object.<anonymous> (/Users/josephmoniz/Dropbox/workspace/node/rx-router/node_modules/rx/rx.testing.js:22:2)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

This is caused by the rx.testing.js module being loaded before the rx.virtualtime.js module being loaded. Simply shifting the loading order around so dependencies resolve in the correct order solves this.
