### PR TITLE
Use EventEmitter.removeListener instead of the nonexistent 'off' method

### DIFF
--- a/rx.node.js
+++ b/rx.node.js
@@ -90,7 +90,7 @@ Rx.Node = {
             eventEmitter.on(eventName, handler);
 
             return function () {
-                eventEmitter.off(eventName, handler);
+                eventEmitter.removeListener(eventName, handler);
             }
         }).publish().refCount();
     },
@@ -144,11 +144,11 @@ Rx.Node = {
             stream.on('data', dataHandler);
             stream.on('error', errorHandler);
             stream.on('end', endHandler);
-            
+
             return function () {
-                stream.off('data', dataHandler);
-                stream.off('error', errorHandler);
-                stream.off('end', endHandler);
+                stream.removeListener('data', dataHandler);
+                stream.removeListener('error', errorHandler);
+                stream.removeListener('end', endHandler);
             };
         }).publish().refCount();
     },


### PR DESCRIPTION
method.

Without this patch, you get an error that looks like this:

TypeError: Object #<ReadStream> has no method 'off'
    at null.action (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.node.js:145:24)
    at Disposable.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:612:18)
    at SingleAssignmentDisposablePrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:701:17)
    at AutoDetachObserverPrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:4668:20)
    at SingleAssignmentDisposablePrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:701:17)
    at AutoDetachObserverPrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:4668:20)
    at CompositeDisposablePrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:554:39)
    at null.action (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.binding.js:524:49)
    at Disposable.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:612:18)
    at SingleAssignmentDisposablePrototype.dispose (/Users/duncan/git/duncanmak/test-project/node_modules/rx/rx.js:701:17)
