### PR TITLE
add rx*timer* files to examples/testing required by Qunit and Jasmine te...

### DIFF
--- a/examples/testing/jasmine/SpecRunner.html
+++ b/examples/testing/jasmine/SpecRunner.html
@@ -11,6 +11,8 @@
 
   <!-- include source files here... -->
   <script type="text/javascript" src="../../../rx.js"></script>
+  <script type="text/javascript" src="../../../rx.virtualtime.js"></script>
+  <script type="text/javascript" src="../../../rx.time.js"></script>
   <script type="text/javascript" src="../../../rx.testing.js"></script>
 
   <!-- include spec files here... -->

--- a/examples/testing/qunit/tests.html
+++ b/examples/testing/qunit/tests.html
@@ -8,6 +8,8 @@
         <div id="qunit"></div>
         <script src="qunit.js"></script>
         <script src="../../../rx.js"></script>
+        <script src="../../../rx.virtualtime.js"></script>
+        <script src="../../../rx.time.js"></script>
         <script src="../../../rx.testing.js"></script>
         <script src="customassertions.js"></script>
         <script src="tests.js"></script>


### PR DESCRIPTION
...sts.

Node tests are working, but require mocha installed globally. Might be good to add that info to examples/readme.md 

`npm install -g mocha`

run  test by using `mocha tests` in the `examples/testing/nodejs` sub directory. 
