### PR TITLE
Fix disposable example to use Rx.Disposable

### DIFF
--- a/doc/api/core/observable.md
+++ b/doc/api/core/observable.md
@@ -520,9 +520,9 @@ var source = Rx.Observable.create(function (observer) {
     observer.onCompleted();
 
     // Note that this is optional, you do not have to return this if you require no cleanup
-    return function () {
+    return Rx.Disposable.create(function () {
         console.log('disposed');
-    };
+    });
 });
 
 var subscription = source.subscribe(


### PR DESCRIPTION
Just a documentation fix, but the example reads as if it was intended to use `Rx.Disposable`, however it's actually identical to the first example which merely returns a function.
