### PR TITLE
Include Observable.prototype.shareReplay in all/allcompat/binding dists

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -312,6 +312,7 @@ var browsers = [{
               'src/core/linq/observable/publishvalue.js', // multicast, BehaviorSubject
               'src/core/linq/observable/sharevalue.js', // multicast, BehaviorSubject, Reference counted
               'src/core/linq/observable/replay.js', // multicast, ReplaySubject
+              'src/core/linq/observable/sharereplay.js', // multicast, ReplaySubject, Reference counted
               'src/core/linq/observable/replayWhileObserved.js', // multicast, ReplaySubject, Reference counted
               'src/core/subjects/innersubscription.js',
               'src/core/subjects/behaviorsubject.js',
@@ -570,6 +571,7 @@ var browsers = [{
               'src/core/linq/observable/publishvalue.js', // multicast, BehaviorSubject
               'src/core/linq/observable/sharevalue.js', // multicast, BehaviorSubject, Reference counted
               'src/core/linq/observable/replay.js', // multicast, ReplaySubject
+              'src/core/linq/observable/sharereplay.js', // multicast, ReplaySubject, Reference counted
               'src/core/linq/observable/replayWhileObserved.js', // multicast, ReplaySubject, Reference counted
               'src/core/subjects/innersubscription.js',
               'src/core/subjects/behaviorsubject.js',
@@ -1387,6 +1389,7 @@ var browsers = [{
               'src/core/linq/observable/publishvalue.js', // multicast, BehaviorSubject
               'src/core/linq/observable/sharevalue.js', // multicast, BehaviorSubject, Reference counted
               'src/core/linq/observable/replay.js', // multicast, ReplaySubject
+              'src/core/linq/observable/sharereplay.js', // multicast, ReplaySubject, Reference counted
               'src/core/linq/observable/replayWhileObserved.js', // multicast, ReplaySubject, Reference counted
               'src/core/subjects/innersubscription.js',
               'src/core/subjects/behaviorsubject.js',


### PR DESCRIPTION
I believe it's omitted from these dist packages by mistake, since the [`shareReplay` documentation](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/observable.md#rxobservableprototypesharereplaybuffersize-window-scheduler) lists them?
