### PR TITLE
fix(switchCase): promise fall through

### DIFF
--- a/src/core/linq/observable/case.js
+++ b/src/core/linq/observable/case.js
@@ -1,27 +1,29 @@
    /**
    *  Uses selector to determine which source in sources to use.
    *  There is an alias 'switchCase' for browsers <IE9.
-   *  
+   *
    * @example
    *  1 - res = Rx.Observable.case(selector, { '1': obs1, '2': obs2 });
    *  1 - res = Rx.Observable.case(selector, { '1': obs1, '2': obs2 }, obs0);
    *  1 - res = Rx.Observable.case(selector, { '1': obs1, '2': obs2 }, scheduler);
-   * 
+   *
    * @param {Function} selector The function which extracts the value for to test in a case statement.
    * @param {Array} sources A object which has keys which correspond to the case statement labels.
    * @param {Observable} [elseSource] The observable sequence or Promise that will be run if the sources are not matched. If this is not provided, it defaults to Rx.Observabe.empty with the specified scheduler.
-   *       
-   * @returns {Observable} An observable sequence which is determined by a case statement.  
+   *
+   * @returns {Observable} An observable sequence which is determined by a case statement.
    */
   Observable['case'] = Observable.switchCase = function (selector, sources, defaultSourceOrScheduler) {
     return observableDefer(function () {
       defaultSourceOrScheduler || (defaultSourceOrScheduler = observableEmpty());
 
       typeof defaultSourceOrScheduler.now === 'function' && (defaultSourceOrScheduler = observableEmpty(defaultSourceOrScheduler));
-      
-      var result = sources[selector()];
-      isPromise(result) && (result = observableFromPromise(result));
-      
-      return result || defaultSourceOrScheduler;
+
+      var result = selector();
+      var source = sources[result] || (isPromise(result) && observableFromPromise(result.then(function(key) {
+        return sources[key] || defaultSourceOrScheduler;
+      })).mergeObservable());
+
+      return source || defaultSourceOrScheduler;
     });
   };


### PR DESCRIPTION
correctly return an Observable when the result is a Promise. The previous code ran 

``` javascript
var result = sources[Promise];
isPromise(undefined) && (result = observableFromPromise(undefined));

return undefined || defaultSourceOrScheduler;
```

which then ran the default case
