### PR TITLE
Support objectMode streams in Node.js

### DIFF
--- a/rx.node.js
+++ b/rx.node.js
@@ -120,7 +120,7 @@ Rx.Node = {
   writeToStream: function (observable, stream, encoding) {
     return observable.subscribe(
       function (x) {
-        stream.write(String(x), encoding);
+        stream.write(x, encoding);
       },
       function (err) {
         stream.emit('error', err);


### PR DESCRIPTION
Write original object to stream instead of its stringified version. This fixes writing objects to streams created as [Writable({objectMode: true})](http://nodejs.org/api/stream.html#stream_new_stream_writable_options).
