### PR TITLE
Fixing #232 by adding thisArg param to Observable.flatMap

### DIFF
--- a/src/core/linq/observable/selectmany.js
+++ b/src/core/linq/observable/selectmany.js
@@ -1,6 +1,6 @@
-    function selectMany(selector) {
+    function selectMany(selector, thisArg) {
       return this.select(function (x, i) {
-        var result = selector(x, i);
+        var result = selector.call(thisArg, x, i);
         return isPromise(result) ? observableFromPromise(result) : result;
       }).mergeObservable();
     }
@@ -42,9 +42,10 @@
      * @param selector A transform function to apply to each element or an observable sequence to project each element from the 
      * source sequence onto which could be either an observable or Promise.
      * @param {Function} [resultSelector]  A transform function to apply to each element of the intermediate sequence.
+     * @param {Any} [thisArg] Object to use as this when executing callback.
      * @returns {Observable} An observable sequence whose elements are the result of invoking the one-to-many transform function collectionSelector on each element of the input sequence and then mapping each of those sequence elements and their corresponding source element to a result element.   
      */
-    observableProto.selectMany = observableProto.flatMap = function (selector, resultSelector) {
+    observableProto.selectMany = observableProto.flatMap = function (selector, resultSelector, thisArg) {
       if (resultSelector) {
           return this.selectMany(function (x, i) {
             var selectorResult = selector(x, i),
@@ -53,12 +54,12 @@
             return result.select(function (y) {
               return resultSelector(x, y, i);
             });
-          });
+          }, thisArg);
       }
       if (typeof selector === 'function') {
-        return selectMany.call(this, selector);
+        return selectMany.call(this, selector, thisArg);
       }
       return selectMany.call(this, function () {
         return selector;
-      });
+      }, thisArg);
     };


### PR DESCRIPTION
Hi there, here's a quick fix allowing a `thisArg` param for `flatMap`. In order not to break backwards compatibility I've added the `thisArg` param as third and last param to `flatMap` even though it can result in "ugly looking" calls to the method (e.g., `obs.flatMap(obj.callback, undefined, obj)`) if you're not using the 2nd param. 
