### PR TITLE
Fix initial pausing in pausableBuffered

### DIFF
--- a/src/core/backpressure/pausable.js
+++ b/src/core/backpressure/pausable.js
@@ -21,7 +21,7 @@
 
     function PausableObservable(source, pauser) {
       this.source = source;
-      this.controller = new Rx.Subject();
+      this.controller = new Subject();
 
       if (pauser && pauser.subscribe) {
         this.pauser = this.controller.merge(pauser);

--- a/src/core/backpressure/pausablebuffered.js
+++ b/src/core/backpressure/pausablebuffered.js
@@ -52,7 +52,7 @@
       var subscription =  
         combineLatestSource(
           this.source,
-          this.pauser.distinctUntilChanged(),
+          this.pauser.distinctUntilChanged().startWith(false),
           function (data, shouldFire) {
             return { data: data, shouldFire: shouldFire };      
           })
@@ -91,14 +91,12 @@
               observer.onCompleted();              
             }
           );
-      this.pause();
-
       return subscription;      
     }
 
     function PausableBufferedObservable(source, pauser) {
       this.source = source;
-      this.controller = new Rx.Subject();
+      this.controller = new Subject();
 
       if (pauser && pauser.subscribe) {
         this.pauser = this.controller.merge(pauser);

--- a/tests/observable/pausablebuffered.js
+++ b/tests/observable/pausablebuffered.js
@@ -241,3 +241,33 @@ test('paused_with_observable_controller_and_pause_and_unpause', function(){
     onCompleted(500)
   );
 });
+
+test('paused with immediate unpause', function(){
+  var subscription;
+
+  var scheduler = new TestScheduler();
+
+  var results = scheduler.createObserver();
+
+  var xs = scheduler.createHotObservable(
+    onNext(150, 1),
+    onNext(210, 2),
+    onCompleted(500)
+  );
+
+  var controller = Rx.Observable.return(true);
+
+  var pausableBuffered = xs.pausableBuffered(controller);
+
+  scheduler.scheduleAbsolute(200, function () {
+    subscription = pausableBuffered.subscribe(results);
+  });
+
+  scheduler.start();
+
+  results.messages.assertEqual(
+    onNext(210, 2),
+    onCompleted(500)
+  );
+
+});


### PR DESCRIPTION
Previously `this.pause()` was called after subscribing which made the initial pause
happen after any values that were published to the `pauser` using `Rx.Scheduler.immediate`.
