### PR TITLE
Fix caching previousShouldFire in pausableBuffered

### DIFF
--- a/src/core/backpressure/pausablebuffered.js
+++ b/src/core/backpressure/pausablebuffered.js
@@ -59,6 +59,7 @@
           .subscribe(
             function (results) {
               if (previousShouldFire !== undefined && results.shouldFire != previousShouldFire) {
+                previousShouldFire = results.shouldFire;
                 // change in shouldFire
                 if (results.shouldFire) {
                   while (q.length > 0) {
@@ -66,6 +67,7 @@
                   }
                 }
               } else {
+                previousShouldFire = results.shouldFire;
                 // new data
                 if (results.shouldFire) {
                   observer.onNext(results.data);
@@ -73,9 +75,7 @@
                   q.push(results.data);
                 }
               }
-              previousShouldFire = results.shouldFire;
-
-            }, 
+            },
             function (err) {
               // Empty buffer before sending error
               while (q.length > 0) {


### PR DESCRIPTION
Assigning `previousShouldFire = results.shouldFire;` must be done immediately.

Otherwise the call to `observer.onNext` can fire another call to the 
`subscribe` callback before `previousShouldFire` was assigned creating an erroneous result in
`if (previousShouldFire !== undefined && results.shouldFire != previousShouldFire)`

Fixes https://github.com/Reactive-Extensions/RxJS/issues/277
