### PR TITLE
Bugfix: Don't expose result variable as global from deepEquals

### DIFF
--- a/src/core/internal/isequal.js
+++ b/src/core/internal/isequal.js
@@ -227,7 +227,7 @@
       }
     }
     var size = 0;
-    result = true;
+    var result = true;
 
     // add `a` and `b` to the stack of traversed objects
     stackA.push(a);


### PR DESCRIPTION
The deepEquals test method exposes one of its internal variables on the global name space.

PS: This fix is in src/core/internal, the commit does not contain the generated files in dist.
