### PR TITLE
Make links more clickable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,11 @@ And there you have it!
 
 ## Dive In! ##
 
-You can find the documentation [here](https://github.com/Reactive-Extensions/RxJS/tree/master/doc) as well as examples [here](https://github.com/Reactive-Extensions/RxJS/tree/master/examples) and plenty of [unit tests](https://github.com/Reactive-Extensions/RxJS/tree/master/tests).
+Please check out:
+
+ - [The full documentation](https://github.com/Reactive-Extensions/RxJS/tree/master/doc)
+ - [Our great set of examples](https://github.com/Reactive-Extensions/RxJS/tree/master/examples)
+ - [Our numerous unit tests](https://github.com/Reactive-Extensions/RxJS/tree/master/tests).
 
 ## Resources
 


### PR DESCRIPTION
Previously the Dive in section was one small paragraph with three small "here" links that was very easy to miss when scrolling up and down the README looking for the meat of the documentation.

I updated this section using bullet points and longer hyperlinks.

It's probably still easy to miss, there might be strong value in taking the README from the docs folder and inlining it into the main README.
