### PR TITLE
Move jscs to seperate file, other rules to todo file, fix styling

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,54 @@
+{
+  "excludeFiles": [
+    "src/core/asyncintro.js",
+    "src/core/intro.js",
+    "src/core/outro.js",
+    "src/core/suboutro.js",
+    "src/core/subintro.js",
+    "src/core/testintro.js"
+  ],
+  "requireCurlyBraces": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "try",
+      "catch"
+  ],
+  "requireOperatorBeforeLineBreak": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "disallowMultipleLineStrings": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+      "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+      "&=", "|=", "^=", "+=",
+
+      "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+      "|", "^", "&&", "||", "===", "==", ">=",
+      "<=", "<", ">", "!=", "!=="
+  ],
+  "requireSpaceAfterBinaryOperators": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpacesInFunctionExpression": {
+      "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInsideParentheses": true,
+  "disallowMultipleLineBreaks": true,
+  "disallowNewlineBeforeBlockStatements": true
+}

--- a/.jscsrc.todo
+++ b/.jscsrc.todo
@@ -1,0 +1,19 @@
+{
+  "maximumLineLength": {
+    "value": 80,
+    "allowComments": true,
+    "allowRegex": true
+  },
+  "validateIndentation": 2,
+  "validateQuoteMarks": "'",
+  "disallowMultipleVarDecl": true,
+  "disallowSpacesInAnonymousFunctionExpression": {
+      "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "validateJSDoc": {
+      "checkParamNames": true,
+      "requireParamTypes": true
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1622,7 +1622,7 @@ var browsers = [{
       jscs: {
         src: 'src/**/*.js',
         options: {
-          "preset": "google"
+          config: '.jscsrc'
         }
       },
       watch: {

--- a/src/core/asyncheader.js
+++ b/src/core/asyncheader.js
@@ -6,7 +6,7 @@
     AnonymousObservable = Rx.AnonymousObservable,
     AsyncSubject = Rx.AsyncSubject,
     disposableCreate = Rx.Disposable.create,
-    CompositeDisposable= Rx.CompositeDisposable,
+    CompositeDisposable = Rx.CompositeDisposable,
     immediateScheduler = Rx.Scheduler.immediate,
     timeoutScheduler = Rx.Scheduler.timeout,
     isScheduler = Rx.helpers.isScheduler,

--- a/src/core/concurrency/timeoutscheduler.js
+++ b/src/core/concurrency/timeoutscheduler.js
@@ -41,7 +41,7 @@
           oldHandler = root.onmessage;
       // Test for async
       root.onmessage = function () { isAsync = true; };
-      root.postMessage('','*');
+      root.postMessage('', '*');
       root.onmessage = oldHandler;
 
       return isAsync;

--- a/src/core/internal/dictionary.js
+++ b/src/core/internal/dictionary.js
@@ -34,7 +34,7 @@
       if (!str.length) { return hash; }
       for (var i = 0, len = str.length; i < len; i++) {
         var character = str.charCodeAt(i);
-        hash = ((hash<<5)-hash)+character;
+        hash = ((hash << 5) - hash) + character;
         hash = hash & hash;
       }
       return hash;

--- a/src/core/internal/enumerable.js
+++ b/src/core/internal/enumerable.js
@@ -12,7 +12,7 @@
       var e;
       try {
         e = sources[$iterator$]();
-      } catch(err) {
+      } catch (err) {
         observer.onError();
         return;
       }
@@ -60,7 +60,7 @@
       var e;
       try {
         e = sources[$iterator$]();
-      } catch(err) {
+      } catch (err) {
         observer.onError();
         return;
       }

--- a/src/core/internal/isequal.js
+++ b/src/core/internal/isequal.js
@@ -20,7 +20,7 @@
 
   try {
     suportNodeClass = !(toString.call(document) == objectClass && !({ 'toString': 0 } + ''));
-  } catch(e) {
+  } catch (e) {
     suportNodeClass = true;
   }
 
@@ -182,10 +182,10 @@
 
       case numberClass:
         // treat `NaN` vs. `NaN` as equal
-        return (a != +a)
-          ? b != +b
+        return (a != +a) ?
+          b != +b :
           // but treat `-0` vs. `+0` as not equal
-          : (a == 0 ? (1 / a == 1 / b) : a == +b);
+          (a == 0 ? (1 / a == 1 / b) : a == +b);
 
       case regexpClass:
       case stringClass:

--- a/src/core/linq/observable/_findvalue.js
+++ b/src/core/linq/observable/_findvalue.js
@@ -5,7 +5,7 @@
                 var shouldRun;
                 try {
                     shouldRun = predicate.call(thisArg, x, i, source);
-                } catch(e) {
+                } catch (e) {
                     observer.onError(e);
                     return;
                 }

--- a/src/core/linq/observable/combinedsynchronized.js
+++ b/src/core/linq/observable/combinedsynchronized.js
@@ -24,4 +24,3 @@
        },
        combineFunction);
    };
-  

--- a/src/core/linq/observable/fromevent.js
+++ b/src/core/linq/observable/fromevent.js
@@ -26,12 +26,12 @@
         event.relatedTarget = event.toElement;
       }
       // Adding stopPropogation and preventDefault to IE
-      if (!event.stopPropagation){
+      if (!event.stopPropagation) {
         event.stopPropagation = stopPropagation;
         event.preventDefault = preventDefault;
       }
       // Normalize key events
-      switch(event.type){
+      switch (event.type) {
         case 'keypress':
           var c = ('charCode' in event ? event.charCode : event.keyCode);
           if (c == 10) {

--- a/src/core/linq/observable/join.js
+++ b/src/core/linq/observable/join.js
@@ -84,7 +84,7 @@
             var result;
             try {
               result = resultSelector(v, value);
-            } catch(exn) {
+            } catch (exn) {
               observer.onError(exn);
               return;
             }

--- a/src/core/linq/observable/spawn.js
+++ b/src/core/linq/observable/spawn.js
@@ -41,7 +41,7 @@
             return --pending || done(null, results);
           }
 
-          fn.call(ctx, function(err, res){
+          fn.call(ctx, function(err, res) {
             if (finished) { return; }
 
             if (err) {
@@ -76,7 +76,7 @@
   }
 
   function promiseToThunk(promise) {
-    return function(fn){
+    return function(fn) {
       promise.then(function(res) {
         fn(null, res);
       }, fn);
@@ -132,7 +132,9 @@
         var ret;
 
         // multiple args
-        if (arguments.length > 2) res = slice.call(arguments, 1);
+        if (arguments.length > 2) {
+          res = slice.call(arguments, 1);
+        }
 
         if (err) {
           try {
@@ -159,7 +161,7 @@
         if (typeof ret.value === fnString) {
           var called = false;
           try {
-            ret.value.call(ctx, function(){
+            ret.value.call(ctx, function() {
               if (called) {
                 return;
               }
@@ -192,13 +194,13 @@
    * @returns {Function} A function, when executed will continue the state machine.
    */
   Rx.denodify = function (fn) {
-    return function (){
+    return function () {
       var args = slice.call(arguments),
         results,
         called,
         callback;
 
-      args.push(function(){
+      args.push(function() {
         results = arguments;
 
         if (callback && !called) {
@@ -209,7 +211,7 @@
 
       fn.apply(this, args);
 
-      return function (fn){
+      return function (fn) {
         callback = fn;
 
         if (results && !called) {
@@ -222,7 +224,7 @@
 
   function error(err) {
     if (!err) { return; }
-    timeoutScheduler.schedule(function(){
+    timeoutScheduler.schedule(function() {
       throw err;
     });
   }

--- a/src/core/linq/observable/takelast.js
+++ b/src/core/linq/observable/takelast.js
@@ -14,7 +14,7 @@
         q.push(x);
         q.length > count && q.shift();
       }, observer.onError.bind(observer), function () {
-        while(q.length > 0) { observer.onNext(q.shift()); }
+        while (q.length > 0) { observer.onNext(q.shift()); }
         observer.onCompleted();
       });
     });

--- a/src/core/linq/observable/windowwithcount.js
+++ b/src/core/linq/observable/windowwithcount.js
@@ -35,7 +35,7 @@
         function (x) {
           for (var i = 0, len = q.length; i < len; i++) { q[i].onNext(x); }
           var c = n - count + 1;
-          c >=0 && c % skip === 0 && q.shift().onCompleted();
+          c >= 0 && c % skip === 0 && q.shift().onCompleted();
           ++n % skip === 0 && createWindow();
         },
         function (e) {

--- a/src/core/longstacktraces.js
+++ b/src/core/longstacktraces.js
@@ -41,7 +41,6 @@
       stackLine.indexOf("(node.js:") !== -1;
   }
 
-
   function captureLine() {
     if (!hasStacks) { return; }
 

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -30,7 +30,9 @@
     var hasProp = {}.hasOwnProperty;
     var inherits = root.Internals.inherits = function (child, parent) {
         for (var key in parent) {
-            if (key !== 'prototype' && hasProp.call(parent, key)) child[key] = parent[key];
+            if (key !== 'prototype' && hasProp.call(parent, key)) {
+                child[key] = parent[key];
+            }
         }
         function ctor() { this.constructor = child; }
         ctor.prototype = parent.prototype;


### PR DESCRIPTION
You might not like all of these rules - like `function()` vs `function ()` in the preset.
So to be more explicit, I copied the google preset rules to the newly created `.jscsrc` file.

The rules that created a lot of errors (indentation, etc) were moved to `.jscsrc-todo` and can be added/fixed later.
The rest of the files are changes for the rest of the rules.
I excluded the files that were intro/outro.
#359
