### PR TITLE
Fix transposition error in example JS in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,10 +167,10 @@ Finally, we call the subscribe method on our observable sequence to start pullin
 suggestions.subscribe(
   function (data) {
     $('#results')
-      .empty ()
-      .append ($.map function(data[1], (value) {
-        return $('<li>').text (value));
-      });
+      .empty()
+      .append ($.map(data[1], function (value) {
+        return $('<li>').text(value);
+      }));
   },
   function (error) {
     $results.empty().append($'<li>').text('Error:' + error);


### PR DESCRIPTION
The error seems to have been added in ea2b4ed9782a3e645c1ce79f57bea693d4c3c948
