### PR TITLE
Remove useless line in zipArray example

### DIFF
--- a/doc/api/core/operators/ziparray.md
+++ b/doc/api/core/operators/ziparray.md
@@ -11,8 +11,6 @@ Merges the specified observable sequences into one observable sequence by emitti
 
 #### Example
 ```js
-var range = Rx.Observable.range(0, 5);
-
 var source = Rx.Observable.zipArray([1,2,3], function (x) { return x * x; });
 
 var subscription = source.subscribe(


### PR DESCRIPTION
The `range` operator in this example has nothing to do with the actual example.
