### PR TITLE
Fixing check on valueOf type to get correct hash

### DIFF
--- a/src/core/internal/dictionary.js
+++ b/src/core/internal/dictionary.js
@@ -66,7 +66,7 @@
           // Hack check for valueOf
           var valueOf = obj.valueOf();
           if (typeof valueOf === 'number') { return numberHashFn(valueOf); }
-          if (typeof obj === 'string') { return stringHashFn(valueOf); }
+          if (typeof valueOf === 'string') { return stringHashFn(valueOf); }
         }
         if (obj.hashCode) { return obj.hashCode(); }
 


### PR DESCRIPTION
According to the type of `valueOf`, different hash code computation strategies are used, but the second check on `valueOf` type is mistakenly done on `obj` instead, therefore the `string` case of `valueOf` is never properly handled