### PR TITLE
Implement `deepPluck`, a pluck operator for nested properties

### DIFF
--- a/doc/api/core/operators/pluck.md
+++ b/doc/api/core/operators/pluck.md
@@ -1,10 +1,13 @@
 ### `Rx.Observable.prototype.pluck(property)`
-[&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/pluck.js "View in source")
+[&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/pluck.js#L10 "View in source")
 
-Projects each element of an observable sequence into a new form by incorporating the element's index.
+Returns an Observable containing the value of a specified nested property from
+all elements in the Observable sequence. If a property can't be resolved, it
+will return `undefined` for that value.
 
 #### Arguments
-1. `property` *(`String`)*: The property to pluck.
+1. `property` *(`String`)*: The property or properties to pluck. `pluck`
+   accepts an unlimited number of nested property parameters.
 
 #### Returns
 *(`Observable`)*: Returns a new Observable sequence of property values.
@@ -33,6 +36,32 @@ var subscription = source.subscribe(
 // => Next: 0
 // => Next: 1
 // => Next: 2
+// => Completed
+
+// Using nested properties:
+
+var source = Rx.Observable
+    .from([
+        { valueA: { valueB: { valueC: 0 }}},
+        { valueA: { valueB: { valueC: 1 }}},
+        { valueA: { valueB: 2 }},
+    ])
+    .pluck('valueA', 'valueB', 'valueC');
+
+var subscription = source.subscribe(
+    function (x) {
+        console.log('Next: ' + x);
+    },
+    function (err) {
+        console.log('Error: ' + err);
+    },
+    function () {
+        console.log('Completed');
+    });
+
+// => Next: 0
+// => Next: 1
+// => Next: undefined
 // => Completed
 ```
 

--- a/src/core/linq/observable/pluck.js
+++ b/src/core/linq/observable/pluck.js
@@ -1,8 +1,26 @@
   /**
-   * Retrieves the value of a specified property from all elements in the Observable sequence.
-   * @param {String} prop The property to pluck.
+   * Retrieves the value of a specified nested property from all elements in
+   * the Observable sequence.
+   * @param {String} nestedProps The nested property to pluck.
    * @returns {Observable} Returns a new Observable sequence of property values.
    */
-  observableProto.pluck = function (prop) {
-    return this.map(function (x) { return x[prop]; });
+  observableProto.pluck = function () {
+    var args = [].slice.call(arguments);
+    var len = args.length;
+    return this.map(function (x) {
+      if (len === 0) {
+        return undefined;
+      }
+
+      var currentProp = x;
+      for (var i = 0; i < len; i++) {
+        var p = currentProp[args[i]];
+        if (typeof p !== 'undefined') {
+          currentProp = p;
+        } else {
+          return undefined;
+        }
+      }
+      return currentProp;
+    });
   };

--- a/tests/observable/pluck.js
+++ b/tests/observable/pluck.js
@@ -40,3 +40,63 @@ test('Pluck_Completed', function () {
 
     xs.subscriptions.assertEqual(subscribe(200, 400));
 });
+
+test('Deep_Pluck_Nested_Completed', function () {
+    var scheduler = new TestScheduler();
+
+    var xs = scheduler.createHotObservable(
+        onNext(180, {a: {b: {c: 1}}}),
+        onNext(210, {a: {b: {c: 2}}}),
+        onNext(240, {a: {b: {c: 3}}}),
+        onNext(290, {a: {b: {c: 4}}}),
+        onNext(350, {a: {b: {c: 5}}}),
+        onCompleted(400),
+        onNext(410, {a: {b: {c: -1}}}),
+        onCompleted(420),
+        onError(430, new Error('ex'))
+    );
+
+    var results = scheduler.startWithCreate(function () {
+        return xs.pluck('a', 'b', 'c');
+    });
+
+    results.messages.assertEqual(
+        onNext(210, 2),
+        onNext(240, 3),
+        onNext(290, 4),
+        onNext(350, 5),
+        onCompleted(400)
+    );
+
+    xs.subscriptions.assertEqual(subscribe(200, 400));
+});
+
+test('Deep_Pluck_Nested_Edgecases', function () {
+    var scheduler = new TestScheduler();
+
+    var xs = scheduler.createHotObservable(
+        onNext(180, {a: {b: {c: 1}}}),
+        onNext(210, {a: {b: 2}}),
+        onNext(240, {a: {c: {c: 3}}}),
+        onNext(290, {}),
+        onNext(350, {a: {b: {c: 5}}}),
+        onCompleted(400),
+        onNext(410, {a: {b: {c: -1}}}),
+        onCompleted(420),
+        onError(430, new Error('ex'))
+    );
+
+    var results = scheduler.startWithCreate(function () {
+        return xs.pluck('a', 'b', 'c');
+    });
+
+    results.messages.assertEqual(
+        onNext(210, undefined),
+        onNext(240, undefined),
+        onNext(290, undefined),
+        onNext(350, 5),
+        onCompleted(400)
+    );
+
+    xs.subscriptions.assertEqual(subscribe(200, 400));
+});


### PR DESCRIPTION
I found myself implementing this operator time and again in my projects, since it is quite convenient. I thought it would be great to have it in the main RxJS distribution.

`deepPluck` is like `pluck` for nested properties. This would be an example of use:

```js
var source = Rx.Observable
    .from([
        { valueA: { valueB: { valueC: 0 }}},
        { valueA: { valueB: { valueC: 1 }}},
        { valueA: { valueB: 2 }},
    ])
    .deepPluck('valueA', 'valueB', 'valueC');

var subscription = source.subscribe(
    function (x) {
        console.log('Next: ' + x);
    },
    function (err) {
        console.log('Error: ' + err);
    },
    function () {
        console.log('Completed');
    });

// => Next: 0
// => Next: 1
// => Next: undefined
// => Completed
```

`deepPluck` will return `undefined` for any property that can't be resolved, just like `pluck` does.

I included the rx generated files in the PR, please let me know if that's wrong.
