### PR TITLE
Fix select/map operator used with constant

### DIFF
--- a/src/core/perf/operators/map.js
+++ b/src/core/perf/operators/map.js
@@ -63,6 +63,6 @@
   observableProto.map = observableProto.select = function (selector, thisArg) {
     var selectorFn = typeof selector === 'function' ? selector : function () { return selector; };
     return this instanceof MapObservable ?
-      this.internalMap(selector, thisArg) :
+      this.internalMap(selectorFn, thisArg) :
       new MapObservable(this, selectorFn, thisArg);
   };


### PR DESCRIPTION
The version RxJS v2.3.25 has a regression on the `map/select` operator when used with a constant parameter from a `MapObservable` instance.