### PR TITLE
fix Observable.spawn / generator example

### DIFF
--- a/doc/api/core/operators/spawn.md
+++ b/doc/api/core/operators/spawn.md
@@ -12,7 +12,7 @@ Spawns a generator function which allows for Promises, Observable sequences, Arr
 #### Example
 ```js
 var Rx = require('rx');
-var request = require('request').request;
+var request = require('request');
 var get = Rx.Observable.fromNodeCallback(request);
 
 Rx.spawn(function* () {

--- a/doc/gettingstarted/generators.md
+++ b/doc/gettingstarted/generators.md
@@ -61,7 +61,7 @@ For example, we could get the HTML from Bing.com and write it to the console, wi
 
 ```js
 var Rx = require('rx');
-var request = require('request').request;
+var request = require('request');
 var get = Rx.Observable.fromNodeCallback(request);
 
 Rx.spawn(function* () {
@@ -73,7 +73,7 @@ Rx.spawn(function* () {
   } 
 
   console.log(data);
-}());
+})();
 ```
 
 ## Mixing Operators with Generators ##


### PR DESCRIPTION
The previous examples didn't work.

The example in gettingstarted/generators had the wrong order of parantheses.

Additionally both examples were attempting to get the `request` method of the request module, which does not exist / is undefined (the request module itself is a function). As a result it failed with `Error TypeError: Cannot read property 'apply' of undefined
undefined`.
