### PR TITLE
use correct npm link in rx-lite docs

### DIFF
--- a/doc/libraries/rx.lite.md
+++ b/doc/libraries/rx.lite.md
@@ -11,7 +11,7 @@ Files:
 - [`rx.lite.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.compat.js)
 
 NPM Packages:
-- `rx-lite`
+- [`rx`](https://www.npmjs.org/package/rx)
 
 NuGet Packages:
 - [`RxJS-Lite`](https://www.nuget.org/packages/RxJS-Lite/)


### PR DESCRIPTION
Since rx-lite does not exist as a package in npm, as per the other documentation files (e.g. `rx.aggregates.md` the npm link now points to the main rx package