### PR TITLE
override file resolution for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "jam": {
     "main": "dist/rx.all.js"
   },
+  "browser": {
+    "index.js": "dist/rx.all.js"
+  },
   "dependencies": {},
   "devDependencies": {
     "benchmark": "*",


### PR DESCRIPTION
use __dist/rx.all.js__ instead of __index.js__
in browserfied code to get rid of __Rx.Node__