### PR TITLE
What about having a getter for BehaviorSubject value?

### DIFF
--- a/src/core/subjects/behaviorsubject.js
+++ b/src/core/subjects/behaviorsubject.js
@@ -43,7 +43,7 @@
        */
       getValue: function () {
           checkDisposed(this);
-          if (this.error) {
+          if (this.hasError) {
               throw this.error;
           }
           return this.value;

--- a/src/core/subjects/behaviorsubject.js
+++ b/src/core/subjects/behaviorsubject.js
@@ -35,6 +35,20 @@
 
     addProperties(BehaviorSubject.prototype, Observer, {
       /**
+       * Gets the current value or throws an exception.
+       * Value is frozen after onCompleted is called.
+       * After onError is called Value always throws the specified exception.
+       * An exception is always thrown after dispose is called.
+       * @returns {Mixed} The initial value passed to the constructor until OnNext is called; after which, the last value passed to OnNext.
+       */
+      getValue: function () {
+          checkDisposed(this);
+          if (this.error) {
+              throw this.error;
+          }
+          return this.value;
+      },
+      /**
        * Indicates whether the subject has observers subscribed to it.
        * @returns {Boolean} Indicates whether the subject has observers subscribed to it.
        */


### PR DESCRIPTION
What about having a getter for BehaviorSubject value?

After @mattpodwysocki comment for issue #177,
I checked the .NET version of library, which has not just a `value` field, but a property with some guard checks etc.

I wonder if the JS version could also have the same behavior.
And if it should to have or not, or `value` is sufficient for all consumer purposes?

I also added unit test to show the difference.