### PR TITLE
Bump npm/bower versions to 2.4.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs",
-  "version": "2.4.3",
+  "version": "2.4.5",
   "main": [
     "dist/rx.all.js",
     "dist/rx.all.map",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rx",
   "title": "Reactive Extensions for JavaScript (RxJS)",
   "description": "Library for composing asynchronous and event-based operations in JavaScript",
-  "version": "2.4.3",
+  "version": "2.4.5",
   "homepage": "https://github.com/Reactive-Extensions/RxJS",
   "author": {
     "name": "Cloud Programmability Team",


### PR DESCRIPTION
@mattpodwysocki The version bumps in npm/bower files was missed in 2.4.4. I suppose it's too late now so please feel free to merge once you're ready for 2.4.5.

Also, i'm happy to do this on a regular basis so we don't break npm/bower users (e.g. me :).

Thanks.