### PR TITLE
Sorting out debounce/throttle/withSelector methods.

### DIFF
--- a/src/core/linq/observable/debouncewithselector.js
+++ b/src/core/linq/observable/debouncewithselector.js
@@ -48,7 +48,10 @@
     }, source);
   };
 
-  observableProto.throttleWithSelector = function () {
+  /**
+   * @deprecated use #debounceWithSelector instead.
+   */
+  observableProto.throttleWithSelector = function (durationSelector) {
     //deprecate('throttleWithSelector', 'debounceWithSelector');
-    return this.debounceWithSelector.apply(this, arguments);
+    return this.debounceWithSelector(durationSelector);
   };

--- a/ts/rx.time-lite.d.ts
+++ b/ts/rx.time-lite.d.ts
@@ -19,11 +19,21 @@ declare module Rx {
 	export interface Observable<T> {
 		delay(dueTime: Date, scheduler?: IScheduler): Observable<T>;
 		delay(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
+		debounce(dueTime: number, scheduler?: IScheduler): Observable<T>;
+		throttleWithTimeout(dueTime: number, scheduler?: IScheduler): Observable<T>;
+		/**
+		* @deprecated use #debounce or #throttleWithTimeout instead.
+		*/
 		throttle(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
 		timeInterval(scheduler?: IScheduler): Observable<TimeInterval<T>>;
+
 		timestamp(scheduler?: IScheduler): Observable<Timestamp<T>>;
+
 		sample(interval: number, scheduler?: IScheduler): Observable<T>;
 		sample<TSample>(sampler: Observable<TSample>, scheduler?: IScheduler): Observable<T>;
+
 		timeout(dueTime: Date, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
 		timeout(dueTime: number, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
 	}

--- a/ts/rx.time.d.ts
+++ b/ts/rx.time.d.ts
@@ -13,7 +13,12 @@ declare module Rx {
 		delayWithSelector(subscriptionDelay: number, delayDurationSelector: (item: T) => number): Observable<T>;
 
 		timeoutWithSelector<TTimeout>(firstTimeout: Observable<TTimeout>, timeoutdurationSelector?: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
+
 		debounceWithSelector<TTimeout>(debounceDurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
+		/**
+		* @deprecated use #debounceWithSelector instead.
+		*/
+		throttleWithSelector<TTimeout>(debounceDurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
 
 		skipLastWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
 		takeLastWithTime(duration: number, timerScheduler?: IScheduler, loopScheduler?: IScheduler): Observable<T>;


### PR DESCRIPTION
 - fixes for rx-time.js debounce/throttle methods definitions (rx.time.d.ts and rx.time-lite.d.ts)
 - throttleWithSelector JSDoc deprecated comment added
 - throttleWithSelector now uses direct call instead of prototype.apply