### PR TITLE
Fixing typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ The only difference is that we can handle the errors inline with our subscriptio
 
 ## Batteries Included ##
 
-Sure, there are a lot of libraries to get started with RxJS?  Confused on where to get started?  Start out with the complete set of operators with [`rx.all.js`](doc/libraries/rx.complete.md), then you can reduce it to the number of operators that you really need, and perhaps stick with something as small as [`rx.lite.js`](doc/libraries/rx.lite.md).
+Sure, there are a lot of libraries to get started with RxJS. Confused on where to get started?  Start out with the complete set of operators with [`rx.all.js`](doc/libraries/rx.complete.md), then you can reduce it to the number of operators that you really need, and perhaps stick with something as small as [`rx.lite.js`](doc/libraries/rx.lite.md).
 
 This set of libraries include:
 


### PR DESCRIPTION
On line 87, there's a question mark ending a non-question sentence that should be replaced with a period.

![screen shot 2015-04-06 at 4 52 00 pm](https://cloud.githubusercontent.com/assets/6980359/7014736/8977b860-dc7d-11e4-9f4e-67d191ac0955.png)
