### PR TITLE
Fixed the controlled operator recursion issue by making requests async

### DIFF
--- a/src/core/headers/backpressureheader.js
+++ b/src/core/headers/backpressureheader.js
@@ -13,4 +13,6 @@
     timeoutScheduler = Rx.Scheduler.timeout,
     currentThreadScheduler = Rx.Scheduler.currentThread,
     identity = Rx.helpers.identity,
+    //TODO Get some consistency about where this is declared
+    isScheduler = Rx.helpers.isScheduler || Rx.Scheduler.isScheduler,
     checkDisposed = Rx.Disposable.checkDisposed;


### PR DESCRIPTION
Fix #625

Adds option to `controlled()` to pass a scheduler as the second argument.
Defaults to `currentThread` (may want to deprecate that later and switch to defaultScheduler, but that will break the current api).

Threw in a unit test for free.