### PR TITLE
[Doc] Fix doc link throttle

### DIFF
--- a/doc/libraries/rx.lite.md
+++ b/doc/libraries/rx.lite.md
@@ -104,7 +104,7 @@ NuGet Packages:
 - [`tapOnNext`](../api/core/operators/doonnext.md)
 - [`tapOnError`](../api/core/operators/doonerror.md)
 - [`tapOnCompleted`](../api/core/operators/dooncompleted.md)
-- [`throttle`](../api/core/operators/throttle.md)
+- [`throttle`](../api/core/operators/debounce.md)
 - [`throttleFirst`](../api/core/operators/throttlefirst.md)
 - [`timeout`](../api/core/operators/timeout.md)
 - [`timestamp`](../api/core/operators/timestamp.md)

--- a/doc/libraries/rx.lite.md
+++ b/doc/libraries/rx.lite.md
@@ -53,7 +53,7 @@ NuGet Packages:
 - [`concat`](../api/core/operators/concatproto.md)
 - [`concatMap`](../api/core/operators/concatmap.md)
 - [`connect`](../api/core/operators/connect.md)
-- [`debounce`](../api/core/operators/debounce.md)  
+- [`debounce`](../api/core/operators/debounce.md)
 - [`defaultIfEmpty`](../api/core/operators/defaultifempty.md)
 - [`delay`](../api/core/operators/delay.md)
 - [`dematerialize`](../api/core/operators/dematerialize.md)


### PR DESCRIPTION
throttle.md is 404 Not Found.  Change debounce.md.

(doc/libraries/rx.lite.md)

