### PR TITLE
correct example use of scheduler in generator

### DIFF
--- a/doc/gettingstarted/schedulers.md
+++ b/doc/gettingstarted/schedulers.md
@@ -47,7 +47,7 @@ Rx.Observable.generate(
 	function () { return true; },
 	function (x) { return x + 1; },
 	function (x) { return x; },
-	observeOn(Rx.Scheduler.default)
+	Rx.Scheduler.default)
 	.subscribe(...);
 ```
 


### PR DESCRIPTION
If I understand the code, as an alternative to using x.observeOn(scheduler), one can just provide a scheduler to the generate method.

I think the `observeOn` is not necessary (maybe was copy and paste error).

Example should read

```javascript
Rx.Observable.generate(
  0,
  function () { return true; },
  function (x) { return x + 1; },
  function (x) { return x; },
  Rx.Scheduler.default)
  .subscribe(...);
```