### PR TITLE
remove "browser" key from package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "jam": {
     "main": "dist/rx.all.js"
   },
-  "browser": {
-    "index.js": "dist/rx.all.js"
-  },
   "dependencies": {},
   "devDependencies": {
     "benchmark": "*",


### PR DESCRIPTION
...until it blocks usage of Rx.VirtualTime and Rx.Testing modules. See [#673](https://github.com/Reactive-Extensions/RxJS/issues/673).