### PR TITLE
Fix misinterpreted backticks

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -35,11 +35,11 @@ To put it more concretely, if you know how to program against Arrays using the A
   <tr><td><pre><code>getDataFromLocalMemory()
   .filter (s => s != null)
   .map(s => s + 'transformed')
-  .forEach(s => console.log(`next => ${s}`))</code></pre></td>
+  .forEach(s => console.log(\`next => ${s}\`))</code></pre></td>
   <td><pre><code>getDataFromNetwork()
   .filter (s => s != null)
   .map(s => s + 'transformed')
-  .subscribe(s => console.log(`next => ${s}`))</code></pre></td></tr>
+  .subscribe(s => console.log(\`next => ${s}\`))</code></pre></td></tr>
  </tbody>
 </table></center>
 


### PR DESCRIPTION
Oops,

following my PR #695 I noticed that the backticks are parsed as `<code>` elements by markdown. Sorry for overlooking that – here’s the correction.