### PR TITLE
Switched to generateWith*Time methods to use scheduleRecursiveWith*AndState

### DIFF
--- a/src/core/linq/observable/generatewithabsolutetime.js
+++ b/src/core/linq/observable/generatewithabsolutetime.js
@@ -21,12 +21,9 @@
     isScheduler(scheduler) || (scheduler = timeoutScheduler);
     return new AnonymousObservable(function (observer) {
       var first = true,
-        hasResult = false,
-        result,
-        state = initialState,
-        time;
-      return scheduler.scheduleRecursiveWithAbsolute(scheduler.now(), function (self) {
-        hasResult && observer.onNext(result);
+        hasResult = false;
+      return scheduler.scheduleRecursiveWithAbsoluteAndState(initialState, scheduler.now(), function (state, self) {
+        hasResult && observer.onNext(state);
 
         try {
           if (first) {
@@ -36,15 +33,15 @@
           }
           hasResult = condition(state);
           if (hasResult) {
-            result = resultSelector(state);
-            time = timeSelector(state);
+            var result = resultSelector(state);
+            var time = timeSelector(state);
           }
         } catch (e) {
           observer.onError(e);
           return;
         }
         if (hasResult) {
-          self(time);
+          self(result, time);
         } else {
           observer.onCompleted();
         }

--- a/src/core/linq/observable/generatewithrelativetime.js
+++ b/src/core/linq/observable/generatewithrelativetime.js
@@ -21,12 +21,9 @@
     isScheduler(scheduler) || (scheduler = timeoutScheduler);
     return new AnonymousObservable(function (observer) {
       var first = true,
-        hasResult = false,
-        result,
-        state = initialState,
-        time;
-      return scheduler.scheduleRecursiveWithRelative(0, function (self) {
-        hasResult && observer.onNext(result);
+        hasResult = false;
+      return scheduler.scheduleRecursiveWithRelativeAndState(initialState, 0, function (state, self) {
+        hasResult && observer.onNext(state);
 
         try {
           if (first) {
@@ -36,15 +33,15 @@
           }
           hasResult = condition(state);
           if (hasResult) {
-            result = resultSelector(state);
-            time = timeSelector(state);
+            var result = resultSelector(state);
+            var time = timeSelector(state);
           }
         } catch (e) {
           observer.onError(e);
           return;
         }
         if (hasResult) {
-          self(time);
+          self(result, time);
         } else {
           observer.onCompleted();
         }


### PR DESCRIPTION
This PR fixes the inner scheduling of the generateWith*Time operators using the *WithState scheduling variants to avoid having extra variables sitting outside of the closure.