### PR TITLE
Fix for count operator overriding

### DIFF
--- a/src/core/perf/operators/range.js
+++ b/src/core/perf/operators/range.js
@@ -2,7 +2,7 @@
     inherits(RangeObservable, __super__);
     function RangeObservable(start, count, scheduler) {
       this.start = start;
-      this.count = count;
+      this.rangeCount = count;
       this.scheduler = scheduler;
       __super__.call(this);
     }
@@ -22,7 +22,7 @@
     }
 
     RangeSink.prototype.run = function () {
-      var start = this.parent.start, count = this.parent.count, observer = this.observer;
+      var start = this.parent.start, count = this.parent.rangeCount, observer = this.observer;
       function loopRecursive(i, recurse) {
         if (i < count) {
           observer.onNext(start + i);

--- a/src/core/perf/operators/skip.js
+++ b/src/core/perf/operators/skip.js
@@ -2,12 +2,12 @@
     inherits(SkipObservable, __super__);
     function SkipObservable(source, count) {
       this.source = source;
-      this.count = count;
+      this.skipCount = count;
       __super__.call(this);
     }
     
     SkipObservable.prototype.subscribeCore = function (o) {
-      return this.source.subscribe(new InnerObserver(o, this.count));
+      return this.source.subscribe(new InnerObserver(o, this.skipCount));
     };
     
     function InnerObserver(o, c) {

--- a/src/core/perf/operators/take.js
+++ b/src/core/perf/operators/take.js
@@ -3,12 +3,12 @@
     
     function TakeObservable(source, count) {
       this.source = source;
-      this.count = count;
+      this.takeCount = count;
       __super__.call(this);
     }
     
     TakeObservable.prototype.subscribeCore = function (o) {
-      return this.source.subscribe(new InnerObserver(o, this.count));  
+      return this.source.subscribe(new InnerObserver(o, this.takeCount));
     };
     
     function InnerObserver(o, c) {

--- a/tests/observable/count.js
+++ b/tests/observable/count.js
@@ -206,3 +206,39 @@ test('Count_Predicate_PredicateThrows', function () {
     res.messages.assertEqual(onError(230, ex));
     xs.subscriptions.assertEqual(subscribe(200, 230));
 });
+
+test('Count_After_Range', function() {
+
+    var scheduler = new TestScheduler();
+    var xs = Rx.Observable.range(1, 10, scheduler);
+
+    var result = scheduler.startWithCreate(function(){
+        return xs.count();
+    });
+
+    result.messages.assertEqual(onNext(211, 10), onCompleted(211));
+});
+
+test('Count_After_Skip', function() {
+
+    var scheduler = new TestScheduler();
+    var xs = Rx.Observable.range(1, 10, scheduler).skip(1);
+
+    var result = scheduler.startWithCreate(function(){
+        return xs.count();
+    });
+
+    result.messages.assertEqual(onNext(211, 9), onCompleted(211));
+});
+
+test('Count_After_Take', function() {
+
+    var scheduler = new TestScheduler();
+    var xs = Rx.Observable.range(1, 10, scheduler).take(1);
+
+    var result = scheduler.startWithCreate(function(){
+        return xs.count();
+    });
+
+    result.messages.assertEqual(onNext(201, 1), onCompleted(201));
+});


### PR DESCRIPTION
Fixes #712. Private member variables of `skip`, `take` and `range` were overriding the `count()` operator in the prototype chain.
