### PR TITLE
Fix for benchmark.js when using a z-score for determining if the rank…

### DIFF
--- a/tests/perf/vendor/benchmark.js
+++ b/tests/perf/vendor/benchmark.js
@@ -2317,7 +2317,7 @@
       // ...the z-stat is greater than 1.96 or less than -1.96
       // http://www.statisticslectures.com/topics/mannwhitneyu/
       zStat = getZ(u);
-      return abs(zStat) > 1.96 ? (zStat > 0 ? -1 : 1) : 0;
+      return abs(zStat) > 1.96 ? (u == u1 ? 1 : -1) : 0;
     }
     // ...the U value is less than or equal the critical U value
     // http://www.geoib.com/mann-whitney-u-test.html


### PR DESCRIPTION
…sum of the two samples can reject the null hypothesis don't determine result by checking the sign of the zStat as it was determined from u which was chosen to always be the minimum of the two sample ranksums and will always have the same sign.  Instead use the same comparison as is used when using Mann Whitney