### PR TITLE
docs: async/mapping.md - remove err argument from filter

### DIFF
--- a/doc/mapping/async/comparing.md
+++ b/doc/mapping/async/comparing.md
@@ -149,7 +149,7 @@ var async = require('async'),
 
 var files = ['file1.txt', 'file2.txt', 'file3.txt'];
 
-async.filter(files, fs.exists, function (err, results) {
+async.filter(files, fs.exists, function (results) {
 
   results.forEach(function (result) {
     console.log('exists: %s', result);


### PR DESCRIPTION
As the block above the snippet suggests, `filter` does not accept an error argument first!