### PR TITLE
Changed ordering of arguments in 'scan' docs

### DIFF
--- a/doc/api/core/operators/scan.md
+++ b/doc/api/core/operators/scan.md
@@ -1,4 +1,4 @@
-### `Rx.Observable.prototype.scan(accumulator, [seed])`
+### `Rx.Observable.prototype.scan([seed], accumulator)`
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/scan.js "View in source")
 
 Applies an accumulator function over an observable sequence and returns each intermediate result. The optional seed value is used as the initial accumulator value.
@@ -6,8 +6,8 @@ Applies an accumulator function over an observable sequence and returns each int
 For aggregation behavior with no intermediate results, see `Rx.Observable#aggregate` or `Rx.Observable#reduce`.
 
 #### Arguments
-1. `accumulator` *(`Function`)*: An accumulator function to be invoked on each element.
-2. `[seed]` *(`Any`)*: The initial accumulator value.
+1. `[seed]` *(`Any`)*: The initial accumulator value.
+2. `accumulator` *(`Function`)*: An accumulator function to be invoked on each element.
 
 #### Returns
 *(`Observable`)*: An observable sequence which results from the comonadic bind operation.
@@ -36,7 +36,7 @@ var subscription = source.subscribe(
 
 /* With a seed */
 var source = Rx.Observable.range(1, 3)
-    .scan(function (acc, x) { return acc * x; }, 1);
+    .scan(1, function (acc, x) { return acc * x; });
 
 var subscription = source.subscribe(
   function (x) {


### PR DESCRIPTION
The seed argument for scan was documented as being the second argument, but in fact its the first.