### PR TITLE
Deleted arguments

### DIFF
--- a/doc/api/core/operators/asobservable.md
+++ b/doc/api/core/operators/asobservable.md
@@ -2,9 +2,6 @@
 
 Hides the identity of an observable sequence.
 
-#### Arguments
-1. `args` *(Array|arguments)*: Observable sources or Promises competing to react first either as an array or arguments.
-
 #### Returns
 *(`Observable`)*: An observable sequence that hides the identity of the source sequence.
 


### PR DESCRIPTION
`asObservable` operator has no arguments, the doc portion i deleted seems to be a copy from [amb](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/amb.md)