### PR TITLE
Fixed #818. Changed from(Node)Callback lazy behavior.

### DIFF
--- a/src/core/linq/observable/fromnodecallback.js
+++ b/src/core/linq/observable/fromnodecallback.js
@@ -10,31 +10,33 @@
       var len = arguments.length, args = new Array(len);
       for(var i = 0; i < len; i++) { args[i] = arguments[i]; }
 
-      return new AnonymousObservable(function (o) {
-        function handler() {
-          var err = arguments[0];
-          if (err) { return o.onError(err); }
+      var o = new AsyncSubject();
 
-          var len = arguments.length, results = [];
-          for(var i = 1; i < len; i++) { results[i - 1] = arguments[i]; }
+      function handler() {
+        var err = arguments[0];
+        if (err) { return o.onError(err); }
 
-          if (isFunction(selector)) {
-            var results = tryCatch(selector).apply(context, results);
-            if (results === errorObj) { return o.onError(results.e); }
-            o.onNext(results);
+        var len = arguments.length, results = [];
+        for(var i = 1; i < len; i++) { results[i - 1] = arguments[i]; }
+
+        if (isFunction(selector)) {
+          var results = tryCatch(selector).apply(context, results);
+          if (results === errorObj) { return o.onError(results.e); }
+          o.onNext(results);
+        } else {
+          if (results.length <= 1) {
+            o.onNext(results[0]);
           } else {
-            if (results.length <= 1) {
-              o.onNext(results[0]);
-            } else {
-              o.onNext(results);
-            }
+            o.onNext(results);
           }
-
-          o.onCompleted();
         }
 
-        args.push(handler);
-        func.apply(context, args);
-      }).publishLast().refCount();
+        o.onCompleted();
+      }
+
+      args.push(handler);
+      func.apply(context, args);
+
+      return o.asObservable();
     };
   };

--- a/tests/observable/fromcallback.js
+++ b/tests/observable/fromcallback.js
@@ -78,4 +78,37 @@
         ok(true);
       });
   });
+
+  test('FromCallback_Resubscribe', function() {
+
+    var count = 0;
+
+    var res = Observable.fromCallback(
+        function(cb) {
+          cb(++count);
+        })();
+
+    var observer = Rx.Observer.create(
+        function (v) {
+          ok(1);
+        }, function (err) {
+          ok(false);
+        }, function () {
+          ok(true);
+        });
+
+
+    res.subscribe(observer);
+
+    res.subscribe(function (v) {
+      ok(1);
+    }, function (err) {
+      ok(false);
+    }, function () {
+      ok(true);
+    });
+
+    equal(1, count);
+
+  });
 }());

--- a/tests/observable/fromnodecallback.js
+++ b/tests/observable/fromnodecallback.js
@@ -90,4 +90,38 @@
         ok(false);
       });
   });
+
+  test('FromCallback_Resubscribe', function() {
+
+    var count = 0;
+
+    var res = Observable.fromNodeCallback(
+        function(cb) {
+          cb(null, ++count);
+        })();
+
+    var observer = Rx.Observer.create(
+        function (v) {
+          ok(1);
+        }, function (err) {
+          ok(false);
+        }, function () {
+          ok(true);
+        });
+
+
+    res.subscribe(observer);
+
+    res.subscribe(function (v) {
+      ok(1);
+    }, function (err) {
+      ok(false);
+    }, function () {
+      ok(true);
+    });
+
+    equal(1, count);
+
+  });
+
 }());


### PR DESCRIPTION
Fixed #818 by switching to an explicit `AsyncSubject`. In the process also changed the behavior of `from(Node)Callback` such that `Rx.Observable.fromCallback(fn)()` begins execution immediately rather than waiting for subscription. I am open to changing this but it seemed in this case it was a little too committed to being lazy.