### PR TITLE
Fix typo

### DIFF
--- a/doc/api/core/operators/forkjoinproto.md
+++ b/doc/api/core/operators/forkjoinproto.md
@@ -30,7 +30,7 @@ var subscription = source.subscribe(
         console.log('Completed');
     });
 
-// => Next: 44
+// => Next: 45
 // => Completed
 ```
 


### PR DESCRIPTION
According to the documentation, it says forkjoin joins the last items  of the 2 streams so it should be 45. 