### PR TITLE
Correct argument name and indentation in selectMany docs

### DIFF
--- a/doc/api/core/operators/selectmany.md
+++ b/doc/api/core/operators/selectmany.md
@@ -93,22 +93,24 @@ var subscription = source.subscribe(
 
 /* Using an array */
 Rx.Observable.of(2, 3, 5)
-.selectMany(function(outer) {
-  //Return x^2, x^3 and x^4
-  return [x * x, 
-             x * x * x, 
-             x * x * x * x];
-},
-function(outer, inner, outerIndex, innerIndex)
-{
-  return { outer : outer, inner : inner, outerIdx : outerIndex, innerIdx : innerIndex };
-}
+    .selectMany(function(x) {
+        // Return x^2, x^3 and x^4
+        return [
+            x * x, 
+            x * x * x, 
+            x * x * x * x
+        ];
+    },
+    function(outer, inner, outerIndex, innerIndex) {
+        return { outer : outer, inner : inner, outerIdx : outerIndex, innerIdx : innerIndex };
+    }
 ).subscribe(function(next) {
-
-  console.log('Outer: ' + next.outer + ', Inner: ' + next.inner, + 
-              ', InnerIndex: ' + next.innerIdx + ', OuterIndex: ' + next.outerIdx);
+    console.log(
+        'Outer: ' + next.outer + ', Inner: ' + next.inner, + 
+        ', InnerIndex: ' + next.innerIdx + ', OuterIndex: ' + next.outerIdx
+    );
 }, function() {
-  console.log('Completed');
+    console.log('Completed');
 });
 
 //=> Outer: 2, Inner: 4, InnerIndex : 0, OuterIndex : 0

--- a/doc/api/core/operators/selectmany.md
+++ b/doc/api/core/operators/selectmany.md
@@ -46,21 +46,21 @@ source.selectMany([1,2,3]);
 #### Example
 ```js
 var source = Rx.Observable
-    .range(1, 2)
-    .selectMany(function (x) {
-        return Rx.Observable.range(x, 2);
-    });
+  .range(1, 2)
+  .selectMany(function (x) {
+    return Rx.Observable.range(x, 2);
+  });
 
 var subscription = source.subscribe(
-    function (x) {
-        console.log('Next: ' + x);
-    },
-    function (err) {
-        console.log('Error: ' + err);
-    },
-    function () {
-        console.log('Completed');
-    });
+  function (x) {
+    console.log('Next: ' + x);
+  },
+  function (err) {
+    console.log('Error: ' + err);
+  },
+  function () {
+    console.log('Completed');
+  });
 
 // => Next: 1
 // => Next: 2
@@ -70,20 +70,20 @@ var subscription = source.subscribe(
 
 /* Using a promise */
 var source = Rx.Observable.of(1,2,3,4)
-    .selectMany(function (x, i) {
-        return Promise.resolve(x + i);
-    });
+  .selectMany(function (x, i) {
+    return Promise.resolve(x + i);
+  });
 
 var subscription = source.subscribe(
-    function (x) {
-        console.log('Next: ' + x);
-    },
-    function (err) {
-        console.log('Error: ' + err);
-    },
-    function () {
-        console.log('Completed');
-    });
+  function (x) {
+    console.log('Next: ' + x);
+  },
+  function (err) {
+    console.log('Error: ' + err);
+  },
+  function () {
+    console.log('Completed');
+  });
 
 // => Next: 1
 // => Next: 3
@@ -92,26 +92,31 @@ var subscription = source.subscribe(
 // => Completed
 
 /* Using an array */
-Rx.Observable.of(2, 3, 5)
-    .selectMany(function(x) {
-        // Return x^2, x^3 and x^4
-        return [
-            x * x, 
-            x * x * x, 
-            x * x * x * x
-        ];
-    },
-    function(outer, inner, outerIndex, innerIndex) {
-        return { outer : outer, inner : inner, outerIdx : outerIndex, innerIdx : innerIndex };
-    }
-).subscribe(function(next) {
+Rx.Observable.of(2, 3, 5).selectMany(
+  function(x) {
+    // Return x^2, x^3 and x^4
+    return [
+      x * x,
+      x * x * x,
+      x * x * x * x
+    ];
+  },
+
+  function(outer, inner, outerIndex, innerIndex) {
+    return { outer : outer, inner : inner, outerIdx : outerIndex, innerIdx : innerIndex };
+  }
+).subscribe(
+  function(next) {
     console.log(
-        'Outer: ' + next.outer + ', Inner: ' + next.inner, + 
-        ', InnerIndex: ' + next.innerIdx + ', OuterIndex: ' + next.outerIdx
+      'Outer: ' + next.outer + ', Inner: ' + next.inner, +
+      ', InnerIndex: ' + next.innerIdx + ', OuterIndex: ' + next.outerIdx
     );
-}, function() {
+  },
+
+  function() {
     console.log('Completed');
-});
+  }
+);
 
 //=> Outer: 2, Inner: 4, InnerIndex : 0, OuterIndex : 0
 //=> Outer: 2, Inner: 8, InnerIndex : 1, OuterIndex : 0

--- a/doc/api/core/operators/selectmany.md
+++ b/doc/api/core/operators/selectmany.md
@@ -108,7 +108,7 @@ Rx.Observable.of(2, 3, 5).selectMany(
 ).subscribe(
   function(next) {
     console.log(
-      'Outer: ' + next.outer + ', Inner: ' + next.inner, +
+      'Outer: ' + next.outer + ', Inner: ' + next.inner +
       ', InnerIndex: ' + next.innerIdx + ', OuterIndex: ' + next.outerIdx
     );
   },


### PR DESCRIPTION
Previously, the name of the argument being passed in to the selectMany with selector example was `count`, when it should have been `x`. The example was also improperly aligned. I have indented it to 4 spaces.