### PR TITLE
Use 'return' method. Fixes #874

### DIFF
--- a/doc/api/core/operators/for.md
+++ b/doc/api/core/operators/for.md
@@ -24,7 +24,7 @@ var array = [1, 2, 3];
 var source = Rx.Observable.for(
     array,
     function (x) {
-        return Rx.Observable.returnValue(x);
+        return Rx.Observable.return(x);
     });
 
 var subscription = source.subscribe(


### PR DESCRIPTION
`returnValue` was deprecated and replaced by `return` in 3.0.