### PR TITLE
Fix the .ts regex matcher + rebuild .ts files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2560,7 +2560,7 @@ module.exports = function (grunt) {
       var source = grunt.file.read(tsFile);
 
       // source with tests
-      var s = source.match(/module Rx \{([\s\S]*)\}[\s\S]*\(function/);
+      var s = source.match(/module Rx \{([\s\S]*)\}[\s\S]*\(function\s*\(\)\s*\{[\s\S]*\}\)/);
       if (s && s[1]) {
         c = cache[tsFile] = s[1];
 	  }

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -2188,7 +2188,18 @@ declare module Rx {
         *
         * @example
         *  var res = observable.groupByUntil(function (x) { return x.id; }, null,  function () { return Rx.Observable.never(); });
-        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); 
+        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); });
+        *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); }, function (x) { return x.toString(); });
+        * @param {Function} keySelector A function to extract the key for each element.
+        * @param {Function} durationSelector A function to signal the expiration of a group.
+        * @returns {Observable}
+        *  A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+        *  If a group's lifetime expires, a new group with the same key value can be created once an element with such a key value is encoutered.
+        *
+        */
+        groupByUntil<TKey, TElement, TDuration>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, durationSelector: (group: GroupedObservable<TKey, TElement>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
          *  Groups the elements of an observable sequence according to a specified key selector function and comparer and selects the resulting elements by using a specified function.
@@ -2207,7 +2218,15 @@ declare module Rx {
          *
          * @example
          *  var res = observable.groupBy(function (x) { return x.id; });
-         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; 
+         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; });
+         *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; }, function (x) { return x.toString(); });
+         * @param {Function} keySelector A function to extract the key for each element.
+         * @param {Function} [elementSelector]  A function to map each source element to an element in an observable group.
+         * @returns {Observable} A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+         */
+        groupBy<TKey, TElement>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
         * Projects each element of an observable sequence into a new form by incorporating the element's index.
@@ -2509,7 +2528,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -2185,7 +2185,18 @@ declare module Rx {
         *
         * @example
         *  var res = observable.groupByUntil(function (x) { return x.id; }, null,  function () { return Rx.Observable.never(); });
-        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); 
+        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); });
+        *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); }, function (x) { return x.toString(); });
+        * @param {Function} keySelector A function to extract the key for each element.
+        * @param {Function} durationSelector A function to signal the expiration of a group.
+        * @returns {Observable}
+        *  A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+        *  If a group's lifetime expires, a new group with the same key value can be created once an element with such a key value is encoutered.
+        *
+        */
+        groupByUntil<TKey, TElement, TDuration>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, durationSelector: (group: GroupedObservable<TKey, TElement>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
          *  Groups the elements of an observable sequence according to a specified key selector function and comparer and selects the resulting elements by using a specified function.
@@ -2204,7 +2215,15 @@ declare module Rx {
          *
          * @example
          *  var res = observable.groupBy(function (x) { return x.id; });
-         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; 
+         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; });
+         *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; }, function (x) { return x.toString(); });
+         * @param {Function} keySelector A function to extract the key for each element.
+         * @param {Function} [elementSelector]  A function to map each source element to an element in an observable group.
+         * @returns {Observable} A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+         */
+        groupBy<TKey, TElement>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
         * Projects each element of an observable sequence into a new form by incorporating the element's index.
@@ -2506,7 +2525,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).

--- a/ts/rx.coincidence.d.ts
+++ b/ts/rx.coincidence.d.ts
@@ -43,7 +43,18 @@ declare module Rx {
         *
         * @example
         *  var res = observable.groupByUntil(function (x) { return x.id; }, null,  function () { return Rx.Observable.never(); });
-        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); 
+        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); });
+        *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); }, function (x) { return x.toString(); });
+        * @param {Function} keySelector A function to extract the key for each element.
+        * @param {Function} durationSelector A function to signal the expiration of a group.
+        * @returns {Observable}
+        *  A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+        *  If a group's lifetime expires, a new group with the same key value can be created once an element with such a key value is encoutered.
+        *
+        */
+        groupByUntil<TKey, TElement, TDuration>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, durationSelector: (group: GroupedObservable<TKey, TElement>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
         *  Correlates the elements of two sequences based on overlapping durations, and groups the results.
@@ -157,7 +168,15 @@ declare module Rx {
          *
          * @example
          *  var res = observable.groupBy(function (x) { return x.id; });
-         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; 
+         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; });
+         *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; }, function (x) { return x.toString(); });
+         * @param {Function} keySelector A function to extract the key for each element.
+         * @param {Function} [elementSelector]  A function to map each source element to an element in an observable group.
+         * @returns {Observable} A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+         */
+        groupBy<TKey, TElement>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface GroupedObservable<TKey, TElement> extends Observable<TElement> {
         key: TKey;
         underlyingObservable: Observable<TElement>;

--- a/ts/rx.coincidence.es6.d.ts
+++ b/ts/rx.coincidence.es6.d.ts
@@ -43,7 +43,18 @@ declare module Rx {
         *
         * @example
         *  var res = observable.groupByUntil(function (x) { return x.id; }, null,  function () { return Rx.Observable.never(); });
-        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); 
+        *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); });
+        *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; },  function () { return Rx.Observable.never(); }, function (x) { return x.toString(); });
+        * @param {Function} keySelector A function to extract the key for each element.
+        * @param {Function} durationSelector A function to signal the expiration of a group.
+        * @returns {Observable}
+        *  A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+        *  If a group's lifetime expires, a new group with the same key value can be created once an element with such a key value is encoutered.
+        *
+        */
+        groupByUntil<TKey, TElement, TDuration>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, durationSelector: (group: GroupedObservable<TKey, TElement>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface Observable<T> {
         /**
         *  Correlates the elements of two sequences based on overlapping durations, and groups the results.
@@ -157,7 +168,15 @@ declare module Rx {
          *
          * @example
          *  var res = observable.groupBy(function (x) { return x.id; });
-         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; 
+         *  2 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; });
+         *  3 - observable.groupBy(function (x) { return x.id; }), function (x) { return x.name; }, function (x) { return x.toString(); });
+         * @param {Function} keySelector A function to extract the key for each element.
+         * @param {Function} [elementSelector]  A function to map each source element to an element in an observable group.
+         * @returns {Observable} A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+         */
+        groupBy<TKey, TElement>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+    }
+
     export interface GroupedObservable<TKey, TElement> extends Observable<TElement> {
         key: TKey;
         underlyingObservable: Observable<TElement>;

--- a/ts/rx.d.ts
+++ b/ts/rx.d.ts
@@ -2405,7 +2405,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).

--- a/ts/rx.es6.d.ts
+++ b/ts/rx.es6.d.ts
@@ -2402,7 +2402,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).

--- a/ts/rx.lite.d.ts
+++ b/ts/rx.lite.d.ts
@@ -2131,7 +2131,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).

--- a/ts/rx.lite.es6.d.ts
+++ b/ts/rx.lite.es6.d.ts
@@ -2128,7 +2128,15 @@ declare module Rx {
         *  Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
         *  The element's index is used in the logic of the predicate function.
         *
-        *  var res = source.skipWhile(function (value) { return value < 10; 
+        *  var res = source.skipWhile(function (value) { return value < 10; });
+        *  var res = source.skipWhile(function (value, index) { return value < 10 || index < 10; });
+        * @param {Function} predicate A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+        * @param {Any} [thisArg] Object to use as this when executing callback.
+        * @returns {Observable} An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+        */
+        skipWhile(predicate: ((value: T, index: number, observable: Observable<T>) => boolean), thisArg?: any): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Returns a specified number of contiguous elements from the start of an observable sequence, using the specified scheduler for the edge case of take(0).


### PR DESCRIPTION
The previous regex was not good enough and it
was hindered by complex code samples in the
documentation.

One example is in the groupBy/Until files which
are now properly generated.