### PR TITLE
tryCatch no longer uses global state to pass the target

### DIFF
--- a/src/core/internal/trycatch.js
+++ b/src/core/internal/trycatch.js
@@ -1,17 +1,17 @@
   var errorObj = {e: {}};
-  var tryCatchTarget;
-  function tryCatcher() {
-    try {
-      return tryCatchTarget.apply(this, arguments);
-    } catch (e) {
-      errorObj.e = e;
-      return errorObj;
+  function tryCatcherGen(tryCatchTarget) {
+    return function tryCatcher() {
+      try {
+        return tryCatchTarget.apply(this, arguments);
+      } catch (e) {
+        errorObj.e = e;
+        return errorObj;
+      }
     }
   }
-  function tryCatch(fn) {
+  var tryCatch = Rx.internals.tryCatch = function tryCatch(fn) {
     if (!isFunction(fn)) { throw new TypeError('fn must be a function'); }
-    tryCatchTarget = fn;
-    return tryCatcher;
+    return tryCatcherGen(fn);
   }
   function thrower(e) {
     throw e;

--- a/tests/internal/trycatch.js
+++ b/tests/internal/trycatch.js
@@ -1,0 +1,11 @@
+QUnit.module('tryCatch');
+
+var tryCatch = Rx.internals.tryCatch;
+
+test('tryCatch_multiple', function () {
+  var catcher1 = tryCatch(function() { return 1; });
+  var catcher2 = tryCatch(function() { return 2; });
+
+  ok(catcher1() === 1, "Shouldn't store state in global context");
+  ok(catcher2() === 2, "Shouldn't store state in global context");
+});

--- a/tests/rx.html
+++ b/tests/rx.html
@@ -95,6 +95,7 @@
 
   <!-- Individual Tests -->
   <script src="internal/isequal.js"></script>
+  <script src="internal/trycatch.js"></script>
   <script src="subjects/asyncsubject.js"></script>
   <script src="subjects/subject.js"></script>
 


### PR DESCRIPTION
- your "Our contribution guidelines" link in the readme is broken
- passing the error in a global variable should also be avoided (new errors wipe the old ones),
  if needed in the tests a better solution would be to push the errors into a global queue.