### PR TITLE
Fix TypeScript's type definitions for Rx.Observable.fromEvent() accept all `EventTarget` dom objects.

### DIFF
--- a/ts/core/linq/observable/fromevent.ts
+++ b/ts/core/linq/observable/fromevent.ts
@@ -9,15 +9,7 @@ module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
          * @returns {Observable} An observable sequence of events from the specified element and the specified event.
          */
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        /**
-         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
-         * @param {Object} element The DOMElement or NodeList to attach a listener.
-         * @param {String} eventName The event name to attach the observable sequence.
-         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
-         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
-         */
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         /**
          * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
          * @param {Object} element The DOMElement or NodeList to attach a listener.

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -3094,15 +3094,7 @@ declare module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
          * @returns {Observable} An observable sequence of events from the specified element and the specified event.
          */
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        /**
-         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
-         * @param {Object} element The DOMElement or NodeList to attach a listener.
-         * @param {String} eventName The event name to attach the observable sequence.
-         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
-         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
-         */
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         /**
          * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
          * @param {Object} element The DOMElement or NodeList to attach a listener.

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -3116,15 +3116,7 @@ declare module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
          * @returns {Observable} An observable sequence of events from the specified element and the specified event.
          */
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        /**
-         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
-         * @param {Object} element The DOMElement or NodeList to attach a listener.
-         * @param {String} eventName The event name to attach the observable sequence.
-         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
-         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
-         */
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         /**
          * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
          * @param {Object} element The DOMElement or NodeList to attach a listener.

--- a/ts/rx.lite.d.ts
+++ b/ts/rx.lite.d.ts
@@ -2373,15 +2373,7 @@ declare module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
          * @returns {Observable} An observable sequence of events from the specified element and the specified event.
          */
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        /**
-         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
-         * @param {Object} element The DOMElement or NodeList to attach a listener.
-         * @param {String} eventName The event name to attach the observable sequence.
-         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
-         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
-         */
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         /**
          * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
          * @param {Object} element The DOMElement or NodeList to attach a listener.

--- a/ts/rx.lite.es6.d.ts
+++ b/ts/rx.lite.es6.d.ts
@@ -2370,15 +2370,7 @@ declare module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
          * @returns {Observable} An observable sequence of events from the specified element and the specified event.
          */
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        /**
-         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
-         * @param {Object} element The DOMElement or NodeList to attach a listener.
-         * @param {String} eventName The event name to attach the observable sequence.
-         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
-         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
-         */
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         /**
          * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
          * @param {Object} element The DOMElement or NodeList to attach a listener.


### PR DESCRIPTION
By [the current implementation](https://github.com/Reactive-Extensions/RxJS/blob/8b596f6826/src/core/linq/observable/fromevent.js#L1-L13), `Rx.Observable.fromEvent()` can accept all [`EventTarget`](https://github.com/Microsoft/TypeScript/blob/5542e396d71b0a8100164cf24790fffcc5d5bbe2/lib/lib.dom.d.ts#L3197) dom object by default.

But in TypeScript's type definitions, it only accept `Node`/`NodeList`. This is not suitable and not useful if we handle a dom event.

So this commit fixes TypeScript's type definitions to accept all `EventTarget` dom objects for `Rx.Observable.fromEvent()`.