### PR TITLE
Update jsdoc: remove 'unused' tags

### DIFF
--- a/src/core/observer.js
+++ b/src/core/observer.js
@@ -47,9 +47,6 @@
 
   /**
    *  Creates an observer from a notification callback.
-   *
-   * @static
-   * @memberOf Observer
    * @param {Function} handler Action that handles a notification.
    * @returns The observer object that invokes the specified handler using a notification corresponding to each message it receives.
    */


### PR DESCRIPTION
Using a JSDoc comment tag only in one function of the entire code base
is inconsistent. Besides, these two tags are discouraged by the coding style.