### PR TITLE
Correct capitalized link in rx.md

### DIFF
--- a/doc/libraries/main/rx.md
+++ b/doc/libraries/main/rx.md
@@ -109,7 +109,7 @@ NuGet Packages:
 ### Core Objects
 
 - [`Rx.Observer`](../../api/core/observer.md)
-- [`Rx.Observable`](../../api/core/Observable.md)
+- [`Rx.Observable`](../../api/core/observable.md)
 - [`Rx.Notification`](../../api/core/notification.md)
 
 ### Subjects


### PR DESCRIPTION
Link to Rx.Observable was capitalized which led to a 404.  Dropped to lower case.