### PR TITLE
deal in Dates in observableTimerDateAndPeriod - Fixes #941

### DIFF
--- a/src/core/linq/observable/_observabletimerdateandperiod.js
+++ b/src/core/linq/observable/_observabletimerdateandperiod.js
@@ -4,8 +4,8 @@
       return scheduler.scheduleRecursiveFuture(0, d, function (count, self) {
         if (p > 0) {
           var now = scheduler.now();
-          d = d + p;
-          d <= now && (d = now + p);
+          d = new Date(d.getTime() + p);
+          d.getTime() <= now && (d = new Date(now + p));
         }
         observer.onNext(count);
         self(count + 1, new Date(d));

--- a/tests/observable/timer.js
+++ b/tests/observable/timer.js
@@ -70,4 +70,19 @@
     raises(function () { scheduler2.start(); });
   });
 
+  test('timer relative start and periodically repeat', function() {
+    var scheduler = new TestScheduler();
+
+    var results = scheduler.startScheduler(function() {
+      return Rx.Observable.timer(300, 100, scheduler);
+    });
+
+    results.messages.assertEqual(
+      onNext(500, 0),
+      onNext(600, 1),
+      onNext(700, 2),
+      onNext(800, 3),
+      onNext(900, 4)
+    );
+  });
 }());


### PR DESCRIPTION
I hit this bug after working through the timer example in `doc/gettingstarted/creating.md` (as I imagine others will) this patch fixed the incorrect behavior for me.