### PR TITLE
Fix broken link

### DIFF
--- a/doc/api/core/observable.md
+++ b/doc/api/core/observable.md
@@ -159,7 +159,7 @@ The Observer and Observable interfaces provide a generalized mechanism for push-
 - [`skipUntilWithTime`](operators/skipuntilwithtime.md)
 - [`skipWhile`](operators/skipwhile.md)
 - [`slice`](operators/slice.md)
-- [`some`](operators/any.md)
+- [`some`](operators/some.md)
 - [`startWith`](operators/startwith.md)
 - [`subscribe | forEach`](operators/subscribe.md)
 - [`subscribeOnNext`](operators/subscribeonnext.md)


### PR DESCRIPTION
'some' links to operators/any.md (404) -> should link to operators/some.md