### PR TITLE
add solution for BehaviorSubject without initial value

### DIFF
--- a/doc/api/subjects/behaviorsubject.md
+++ b/doc/api/subjects/behaviorsubject.md
@@ -1,6 +1,6 @@
 # `Rx.BehaviorSubject` class #
 
-Represents a value that changes over time.  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+Represents a value that changes over time.  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications. If you are looking for BehaviorSubject without initial value see [`Rx.ReplaySubject`](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/subjects/replaysubject.md).
 
 This class inherits both from the `Rx.Observable` and `Rx.Observer` classes.
 


### PR DESCRIPTION
Hi guys
In my opinion BehaviorSubject will be more useful if the initial value is not required.
[RxJava does implement the feature](/ReactiveX/RxJava/pull/1185/files?w=1) but the RxJS maintainer seems to [declined the pull request about this matter](/Reactive-Extensions/RxJS/pull/27).

Here my attempt to fix the issue by fixing it in the documentation instead.
It is along the line of changing.
```js
var subject = new Rx.BehaviorSubject(42);

var subscription = subject.subscribe(
    function (x) {
        console.log('Next: ' + x.toString());
    },
    function (err) {
        console.log('Error: ' + err);
    },
    function () {
        console.log('Completed');
    });
```

to
```js
var subject = new Rx.ReplaySubject(1);

var subscription = subject.take(1).subscribe(
    function (x) {
        console.log('Next: ' + x.toString());
    },
    function (err) {
        console.log('Error: ' + err);
    },
    function () {
        console.log('Completed');
    });

// use subject as observer somewhere else
```