### PR TITLE
Fixes in rebuild-ts grunt task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2619,7 +2619,9 @@ module.exports = function (grunt) {
       }
 
 	  if (!(concatKey === 'all' || concatKey === 'main' || concatKey === 'lite' || concatKey === 'core')) {
-		if (allLoadedFiles['lite'][tsFile] || allLoadedFiles['core'][tsFile]) {
+		if ((concatKey.indexOf('lite') === 0 && allLoadedFiles['lite'][tsFile])
+		    || (concatKey.indexOf('lite') !== 0 && allLoadedFiles['main'][tsFile])
+		    || allLoadedFiles['core'][tsFile]) {
 		  loadedFiles[tsFile] = true;
 		  return;
 		}
@@ -2655,7 +2657,7 @@ module.exports = function (grunt) {
 	    continue;
 	  }
 
-	  if (key === 'lite' || key === 'core') {
+	  if (key === 'lite' || key === 'main' || key === 'core') {
 		items.unshift(key);
 	  } else {
 		items.push(key);
@@ -2717,7 +2719,7 @@ module.exports = function (grunt) {
 		if (concatKey === 'all' || concatKey === 'main' || concatKey === 'lite' || concatKey === 'core') {
 		  outputString += '\ndeclare module "rx" { export = Rx; }\n';
 		}
-		if (dist && concatKey !== 'core') {
+		if (dist && concatKey !== 'core' && concatKey !== 'main') {
 		  outputString += 'declare module "'+dist+'" { export = Rx; }';
 		}
 

--- a/ts/rx.async.d.ts
+++ b/ts/rx.async.d.ts
@@ -69,5 +69,220 @@ declare module Rx {
         toAsync<T1, T2, T3, T4, TResult>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult, context?: any, scheduler?: IScheduler): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
     }
 
+    export interface ObservableStatic {
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult>(func: Function, context: any, selector: Function): (...args: any[]) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1>(func: (arg1: T1, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2>(func: (arg1: T1, arg2: T2, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3>(func: (arg1: T1, arg2: T2, arg3: T3, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult>(func: Function, context?: any, selector?: Function): (...args: any[]) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1>(func: (arg1: T1, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2>(func: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3>(func: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
+         * @param {Object} element The DOMElement or NodeList to attach a listener.
+         * @param {String} eventName The event name to attach the observable sequence.
+         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
+         */
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        /**
+         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
+         * @param {Object} element The DOMElement or NodeList to attach a listener.
+         * @param {String} eventName The event name to attach the observable sequence.
+         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
+         */
+        fromEvent<T>(element: { on: (name: string, cb: (e: any) => any) => void; off: (name: string, cb: (e: any) => any) => void }, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+    }
+
+    export interface ObservableStatic {
+        /**
+        * Creates an observable sequence from an event emitter via an addHandler/removeHandler pair.
+        * @param {Function} addHandler The function to add a handler to the emitter.
+        * @param {Function} [removeHandler] The optional function to remove a handler from an emitter.
+        * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+        * @returns {Observable} An observable sequence which wraps an event from an event emitter
+        */
+        fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
+    }
+
+    export interface ObservableStatic {
+        /**
+        * Invokes the asynchronous function, surfacing the result through an observable sequence.
+        * @param {Function} functionAsync Asynchronous function which returns a Promise to run.
+        * @returns {Observable} An observable sequence exposing the function's result value, or an exception.
+        */
+        startAsync<T>(functionAsync: () => IPromise<T>): Observable<T>;
+    }
+
 }
 declare module "rx.async" { export = Rx; }

--- a/ts/rx.async.es6.d.ts
+++ b/ts/rx.async.es6.d.ts
@@ -69,5 +69,220 @@ declare module Rx {
         toAsync<T1, T2, T3, T4, TResult>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult, context?: any, scheduler?: IScheduler): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
     }
 
+    export interface ObservableStatic {
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult>(func: Function, context: any, selector: Function): (...args: any[]) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1>(func: (arg1: T1, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2>(func: (arg1: T1, arg2: T2, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3>(func: (arg1: T1, arg2: T2, arg3: T3, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult>(func: Function, context?: any, selector?: Function): (...args: any[]) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1>(func: (arg1: T1, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2>(func: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3>(func: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
+         * @param {Object} element The DOMElement or NodeList to attach a listener.
+         * @param {String} eventName The event name to attach the observable sequence.
+         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
+         */
+        fromEvent<T>(element: EventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        /**
+         * Creates an observable sequence by adding an event listener to the matching DOMElement or each item in the NodeList.
+         * @param {Object} element The DOMElement or NodeList to attach a listener.
+         * @param {String} eventName The event name to attach the observable sequence.
+         * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+         * @returns {Observable} An observable sequence of events from the specified element and the specified event.
+         */
+        fromEvent<T>(element: { on: (name: string, cb: (e: any) => any) => void; off: (name: string, cb: (e: any) => any) => void }, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+    }
+
+    export interface ObservableStatic {
+        /**
+        * Creates an observable sequence from an event emitter via an addHandler/removeHandler pair.
+        * @param {Function} addHandler The function to add a handler to the emitter.
+        * @param {Function} [removeHandler] The optional function to remove a handler from an emitter.
+        * @param {Function} [selector] A selector which takes the arguments from the event handler to produce a single item to yield on next.
+        * @returns {Observable} An observable sequence which wraps an event from an event emitter
+        */
+        fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
+    }
+
+    export interface ObservableStatic {
+        /**
+        * Invokes the asynchronous function, surfacing the result through an observable sequence.
+        * @param {Function} functionAsync Asynchronous function which returns a Promise to run.
+        * @returns {Observable} An observable sequence exposing the function's result value, or an exception.
+        */
+        startAsync<T>(functionAsync: () => IPromise<T>): Observable<T>;
+    }
+
 }
 declare module "rx.async" { export = Rx; }

--- a/ts/rx.backpressure.d.ts
+++ b/ts/rx.backpressure.d.ts
@@ -1,5 +1,67 @@
 declare module Rx {
 
+    /**
+    * Used to pause and resume streams.
+    */
+    export interface Pauser {
+        /**
+         * Pauses the underlying sequence.
+         */
+        pause(): void;
+
+        /**
+        * Resumes the underlying sequence.
+        */
+        resume(): void;
+    }
+
+    export interface Observable<T> {
+        /**
+         * Pauses the underlying observable sequence based upon the observable sequence which yields true/false.
+         * @example
+         * var pauser = new Rx.Subject();
+         * var source = Rx.Observable.interval(100).pausable(pauser);
+         * @param {Observable} pauser The observable sequence used to pause the underlying sequence.
+         * @returns {Observable} The observable sequence which is paused based upon the pauser.
+         */
+        pausable(pauser?: Observable<boolean>): PausableObservable<T>;
+    }
+
+    export interface PausableObservable<T> extends Observable<T> {
+        pause(): void;
+        resume(): void;
+    }
+
+    export interface Observable<T> {
+        /**
+         * Pauses the underlying observable sequence based upon the observable sequence which yields true/false,
+         * and yields the values that were buffered while paused.
+         * @example
+         * var pauser = new Rx.Subject();
+         * var source = Rx.Observable.interval(100).pausableBuffered(pauser);
+         * @param {Observable} pauser The observable sequence used to pause the underlying sequence.
+         * @returns {Observable} The observable sequence which is paused based upon the pauser.
+         */
+        pausableBuffered(pauser?: Observable<boolean>): PausableObservable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Attaches a controller to the observable sequence with the ability to queue.
+        * @example
+        * var source = Rx.Observable.interval(100).controlled();
+        * source.request(3); // Reads 3 values
+        * @param {bool} enableQueue truthy value to determine if values should be queued pending the next request
+        * @param {Scheduler} scheduler determines how the requests will be scheduled
+        * @returns {Observable} The observable sequence which only propagates values on request.
+        */
+        controlled(enableQueue?: boolean, scheduler?: IScheduler): ControlledObservable<T>;
+    }
+
+    export interface ControlledObservable<T> extends Observable<T> {
+        request(numberOfItems?: number): IDisposable;
+    }
+
     export interface ControlledObservable<T> {
         /**
          * Attaches a stop and wait observable to the current observable.
@@ -15,6 +77,16 @@ declare module Rx {
          * @returns {Observable} A windowed observable based upon the window size.
          */
         windowed(windowSize: number): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Pipes the existing Observable sequence into a Node.js Stream.
+        * @param {Stream} dest The destination Node.js stream.
+        * @returns {Stream} The destination stream.
+        */
+        pipe<TDest>(dest: TDest): TDest;
+        // TODO: Add link to node.d.ts some where
     }
 
 }

--- a/ts/rx.backpressure.es6.d.ts
+++ b/ts/rx.backpressure.es6.d.ts
@@ -1,5 +1,67 @@
 declare module Rx {
 
+    /**
+    * Used to pause and resume streams.
+    */
+    export interface Pauser {
+        /**
+         * Pauses the underlying sequence.
+         */
+        pause(): void;
+
+        /**
+        * Resumes the underlying sequence.
+        */
+        resume(): void;
+    }
+
+    export interface Observable<T> {
+        /**
+         * Pauses the underlying observable sequence based upon the observable sequence which yields true/false.
+         * @example
+         * var pauser = new Rx.Subject();
+         * var source = Rx.Observable.interval(100).pausable(pauser);
+         * @param {Observable} pauser The observable sequence used to pause the underlying sequence.
+         * @returns {Observable} The observable sequence which is paused based upon the pauser.
+         */
+        pausable(pauser?: Observable<boolean>): PausableObservable<T>;
+    }
+
+    export interface PausableObservable<T> extends Observable<T> {
+        pause(): void;
+        resume(): void;
+    }
+
+    export interface Observable<T> {
+        /**
+         * Pauses the underlying observable sequence based upon the observable sequence which yields true/false,
+         * and yields the values that were buffered while paused.
+         * @example
+         * var pauser = new Rx.Subject();
+         * var source = Rx.Observable.interval(100).pausableBuffered(pauser);
+         * @param {Observable} pauser The observable sequence used to pause the underlying sequence.
+         * @returns {Observable} The observable sequence which is paused based upon the pauser.
+         */
+        pausableBuffered(pauser?: Observable<boolean>): PausableObservable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Attaches a controller to the observable sequence with the ability to queue.
+        * @example
+        * var source = Rx.Observable.interval(100).controlled();
+        * source.request(3); // Reads 3 values
+        * @param {bool} enableQueue truthy value to determine if values should be queued pending the next request
+        * @param {Scheduler} scheduler determines how the requests will be scheduled
+        * @returns {Observable} The observable sequence which only propagates values on request.
+        */
+        controlled(enableQueue?: boolean, scheduler?: IScheduler): ControlledObservable<T>;
+    }
+
+    export interface ControlledObservable<T> extends Observable<T> {
+        request(numberOfItems?: number): IDisposable;
+    }
+
     export interface ControlledObservable<T> {
         /**
          * Attaches a stop and wait observable to the current observable.
@@ -15,6 +77,16 @@ declare module Rx {
          * @returns {Observable} A windowed observable based upon the window size.
          */
         windowed(windowSize: number): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Pipes the existing Observable sequence into a Node.js Stream.
+        * @param {Stream} dest The destination Node.js stream.
+        * @returns {Stream} The destination stream.
+        */
+        pipe<TDest>(dest: TDest): TDest;
+        // TODO: Add link to node.d.ts some where
     }
 
 }

--- a/ts/rx.binding.d.ts
+++ b/ts/rx.binding.d.ts
@@ -1,5 +1,250 @@
 declare module Rx {
 
+        export interface ConnectableObservable<T> extends Observable<T> {
+    		connect(): IDisposable;
+    		refCount(): Observable<T>;
+        }
+
+    export interface Observable<T> {
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast(subject: ISubject<T> | (() => ISubject<T>)): ConnectableObservable<T>;
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast<TResult>(subjectSelector: ISubject<T> | (() => ISubject<T>), selector: (source: ConnectableObservable<T>) => Observable<T>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of publish which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        share(): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue(initialValue: T): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>, initialValue: T): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence and starts with an initialValue.
+        * This operator is a specialization of publishValue which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareValue(initialValue: T): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector?: void, bufferSize?: number, window?: number, scheduler?: IScheduler): ConnectableObservable<T>;	// hack to catch first omitted parameter
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector: (source: ConnectableObservable<T>) => Observable<T>, bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        *
+        * @example
+        * var res = source.shareReplay(3);
+        * var res = source.shareReplay(3, 500);
+        * var res = source.shareReplay(3, 500, scheduler);
+        *
+
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param window [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface BehaviorSubject<T> extends Subject<T> {
+        /**
+         * Gets the current value or throws an exception.
+         * Value is frozen after onCompleted is called.
+         * After onError is called always throws the specified exception.
+         * An exception is always thrown after dispose is called.
+         * @returns {Mixed} The initial value passed to the constructor until onNext is called; after which, the last value passed to onNext.
+         */
+        getValue(): T;
+    }
+
+    interface BehaviorSubjectStatic {
+        /**
+         *  Initializes a new instance of the BehaviorSubject class which creates a subject that caches its last value and starts with the specified value.
+         *  @param {Mixed} value Initial value sent to observers when no other value has been received by the subject yet.
+         */
+        new <T>(initialValue: T): BehaviorSubject<T>;
+    }
+
+    /**
+     *  Represents a value that changes over time.
+     *  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+     */
+    export var BehaviorSubject: BehaviorSubjectStatic;
+
+    export interface ReplaySubject<T> extends Subject<T> { }
+
+    interface ReplaySubjectStatic {
+        /**
+         *  Initializes a new instance of the ReplaySubject class with the specified buffer size, window size and scheduler.
+         *  @param {Number} [bufferSize] Maximum element count of the replay buffer.
+         *  @param {Number} [windowSize] Maximum time length of the replay buffer.
+         *  @param {Scheduler} [scheduler] Scheduler the observers are invoked on.
+         */
+        new <T>(bufferSize?: number, window?: number, scheduler?: IScheduler): ReplaySubject<T>;
+    }
+
+    /**
+    * Represents an object that is both an observable sequence as well as an observer.
+    * Each notification is broadcasted to all subscribed and future observers, subject to buffer trimming policies.
+    */
+    export var ReplaySubject: ReplaySubjectStatic;
+
     export interface Observable<T> {
         /**
         * Returns an observable sequence that shares a single subscription to the underlying sequence. This observable sequence

--- a/ts/rx.binding.es6.d.ts
+++ b/ts/rx.binding.es6.d.ts
@@ -1,5 +1,250 @@
 declare module Rx {
 
+        export interface ConnectableObservable<T> extends Observable<T> {
+    		connect(): IDisposable;
+    		refCount(): Observable<T>;
+        }
+
+    export interface Observable<T> {
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast(subject: ISubject<T> | (() => ISubject<T>)): ConnectableObservable<T>;
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast<TResult>(subjectSelector: ISubject<T> | (() => ISubject<T>), selector: (source: ConnectableObservable<T>) => Observable<T>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of publish which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        share(): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue(initialValue: T): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>, initialValue: T): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence and starts with an initialValue.
+        * This operator is a specialization of publishValue which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareValue(initialValue: T): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector?: void, bufferSize?: number, window?: number, scheduler?: IScheduler): ConnectableObservable<T>;	// hack to catch first omitted parameter
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector: (source: ConnectableObservable<T>) => Observable<T>, bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        *
+        * @example
+        * var res = source.shareReplay(3);
+        * var res = source.shareReplay(3, 500);
+        * var res = source.shareReplay(3, 500, scheduler);
+        *
+
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param window [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface BehaviorSubject<T> extends Subject<T> {
+        /**
+         * Gets the current value or throws an exception.
+         * Value is frozen after onCompleted is called.
+         * After onError is called always throws the specified exception.
+         * An exception is always thrown after dispose is called.
+         * @returns {Mixed} The initial value passed to the constructor until onNext is called; after which, the last value passed to onNext.
+         */
+        getValue(): T;
+    }
+
+    interface BehaviorSubjectStatic {
+        /**
+         *  Initializes a new instance of the BehaviorSubject class which creates a subject that caches its last value and starts with the specified value.
+         *  @param {Mixed} value Initial value sent to observers when no other value has been received by the subject yet.
+         */
+        new <T>(initialValue: T): BehaviorSubject<T>;
+    }
+
+    /**
+     *  Represents a value that changes over time.
+     *  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+     */
+    export var BehaviorSubject: BehaviorSubjectStatic;
+
+    export interface ReplaySubject<T> extends Subject<T> { }
+
+    interface ReplaySubjectStatic {
+        /**
+         *  Initializes a new instance of the ReplaySubject class with the specified buffer size, window size and scheduler.
+         *  @param {Number} [bufferSize] Maximum element count of the replay buffer.
+         *  @param {Number} [windowSize] Maximum time length of the replay buffer.
+         *  @param {Scheduler} [scheduler] Scheduler the observers are invoked on.
+         */
+        new <T>(bufferSize?: number, window?: number, scheduler?: IScheduler): ReplaySubject<T>;
+    }
+
+    /**
+    * Represents an object that is both an observable sequence as well as an observer.
+    * Each notification is broadcasted to all subscribed and future observers, subject to buffer trimming policies.
+    */
+    export var ReplaySubject: ReplaySubjectStatic;
+
     export interface Observable<T> {
         /**
         * Returns an observable sequence that shares a single subscription to the underlying sequence. This observable sequence

--- a/ts/rx.core.binding.d.ts
+++ b/ts/rx.core.binding.d.ts
@@ -1,4 +1,249 @@
 declare module Rx {
 
+        export interface ConnectableObservable<T> extends Observable<T> {
+    		connect(): IDisposable;
+    		refCount(): Observable<T>;
+        }
+
+    export interface Observable<T> {
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast(subject: ISubject<T> | (() => ISubject<T>)): ConnectableObservable<T>;
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast<TResult>(subjectSelector: ISubject<T> | (() => ISubject<T>), selector: (source: ConnectableObservable<T>) => Observable<T>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of publish which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        share(): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue(initialValue: T): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>, initialValue: T): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence and starts with an initialValue.
+        * This operator is a specialization of publishValue which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareValue(initialValue: T): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector?: void, bufferSize?: number, window?: number, scheduler?: IScheduler): ConnectableObservable<T>;	// hack to catch first omitted parameter
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector: (source: ConnectableObservable<T>) => Observable<T>, bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        *
+        * @example
+        * var res = source.shareReplay(3);
+        * var res = source.shareReplay(3, 500);
+        * var res = source.shareReplay(3, 500, scheduler);
+        *
+
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param window [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface BehaviorSubject<T> extends Subject<T> {
+        /**
+         * Gets the current value or throws an exception.
+         * Value is frozen after onCompleted is called.
+         * After onError is called always throws the specified exception.
+         * An exception is always thrown after dispose is called.
+         * @returns {Mixed} The initial value passed to the constructor until onNext is called; after which, the last value passed to onNext.
+         */
+        getValue(): T;
+    }
+
+    interface BehaviorSubjectStatic {
+        /**
+         *  Initializes a new instance of the BehaviorSubject class which creates a subject that caches its last value and starts with the specified value.
+         *  @param {Mixed} value Initial value sent to observers when no other value has been received by the subject yet.
+         */
+        new <T>(initialValue: T): BehaviorSubject<T>;
+    }
+
+    /**
+     *  Represents a value that changes over time.
+     *  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+     */
+    export var BehaviorSubject: BehaviorSubjectStatic;
+
+    export interface ReplaySubject<T> extends Subject<T> { }
+
+    interface ReplaySubjectStatic {
+        /**
+         *  Initializes a new instance of the ReplaySubject class with the specified buffer size, window size and scheduler.
+         *  @param {Number} [bufferSize] Maximum element count of the replay buffer.
+         *  @param {Number} [windowSize] Maximum time length of the replay buffer.
+         *  @param {Scheduler} [scheduler] Scheduler the observers are invoked on.
+         */
+        new <T>(bufferSize?: number, window?: number, scheduler?: IScheduler): ReplaySubject<T>;
+    }
+
+    /**
+    * Represents an object that is both an observable sequence as well as an observer.
+    * Each notification is broadcasted to all subscribed and future observers, subject to buffer trimming policies.
+    */
+    export var ReplaySubject: ReplaySubjectStatic;
+
 }
 declare module "rx.core.binding" { export = Rx; }

--- a/ts/rx.core.binding.es6.d.ts
+++ b/ts/rx.core.binding.es6.d.ts
@@ -1,4 +1,249 @@
 declare module Rx {
 
+        export interface ConnectableObservable<T> extends Observable<T> {
+    		connect(): IDisposable;
+    		refCount(): Observable<T>;
+        }
+
+    export interface Observable<T> {
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast(subject: ISubject<T> | (() => ISubject<T>)): ConnectableObservable<T>;
+        /**
+        * Multicasts the source sequence notifications through an instantiated subject into all uses of the sequence within a selector function. Each
+        * subscription to the resulting sequence causes a separate multicast invocation, exposing the sequence resulting from the selector function's
+        * invocation. For specializations with fixed subject types, see Publish, PublishLast, and Replay.
+        *
+        * @example
+        * 1 - res = source.multicast(observable);
+        * 2 - res = source.multicast(function () { return new Subject(); }, function (x) { return x; });
+        *
+        * @param {Function|Subject} subjectOrSubjectSelector
+        * Factory function to create an intermediate subject through which the source sequence's elements will be multicast to the selector function.
+        * Or:
+        * Subject to push source elements into.
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence subject to the policies enforced by the created subject. Specified only if <paramref name="subjectOrSubjectSelector" is a factory function.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        multicast<TResult>(subjectSelector: ISubject<T> | (() => ISubject<T>), selector: (source: ConnectableObservable<T>) => Observable<T>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of Multicast using a regular Subject.
+        *
+        * @example
+        * var resres = source.publish();
+        * var res = source.publish(function (x) { return x; });
+        *
+        * @param {Function} [selector] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publish<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence.
+        * This operator is a specialization of publish which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        share(): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast(): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
+        * This operator is a specialization of Multicast using a AsyncSubject.
+        *
+        * @example
+        * var res = source.publishLast();
+        * var res = source.publishLast(function (x) { return x; });
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will only receive the last notification of the source.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishLast<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue(initialValue: T): ConnectableObservable<T>;
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence and starts with initialValue.
+        * This operator is a specialization of Multicast using a BehaviorSubject.
+        *
+        * @example
+        * var res = source.publishValue(42);
+        * var res = source.publishValue(function (x) { return x.select(function (y) { return y * y; }) }, 42);
+        *
+        * @param {Function} [selector] Optional selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive immediately receive the initial value, followed by all notifications of the source from the time of the subscription on.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        publishValue<TResult>(selector: (source: ConnectableObservable<T>) => Observable<TResult>, initialValue: T): Observable<TResult>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence and starts with an initialValue.
+        * This operator is a specialization of publishValue which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        * @param {Mixed} initialValue Initial value received by observers upon subscription.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareValue(initialValue: T): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector?: void, bufferSize?: number, window?: number, scheduler?: IScheduler): ConnectableObservable<T>;	// hack to catch first omitted parameter
+        /**
+        * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of Multicast using a ReplaySubject.
+        *
+        * @example
+        * var res = source.replay(null, 3);
+        * var res = source.replay(null, 3, 500);
+        * var res = source.replay(null, 3, 500, scheduler);
+        * var res = source.replay(function (x) { return x.take(6).repeat(); }, 3, 500, scheduler);
+        *
+        * @param selector [Optional] Selector function which can use the multicasted source sequence as many times as needed, without causing multiple subscriptions to the source sequence. Subscribers to the given source will receive all the notifications of the source subject to the specified replay buffer trimming policy.
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param windowSize [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
+        */
+        replay(selector: (source: ConnectableObservable<T>) => Observable<T>, bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an observable sequence that shares a single subscription to the underlying sequence replaying notifications subject to a maximum time length for the replay buffer.
+        * This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+        *
+        * @example
+        * var res = source.shareReplay(3);
+        * var res = source.shareReplay(3, 500);
+        * var res = source.shareReplay(3, 500, scheduler);
+        *
+
+        * @param bufferSize [Optional] Maximum element count of the replay buffer.
+        * @param window [Optional] Maximum time length of the replay buffer.
+        * @param scheduler [Optional] Scheduler where connected observers within the selector function will be invoked on.
+        * @returns {Observable} An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+        */
+        shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface BehaviorSubject<T> extends Subject<T> {
+        /**
+         * Gets the current value or throws an exception.
+         * Value is frozen after onCompleted is called.
+         * After onError is called always throws the specified exception.
+         * An exception is always thrown after dispose is called.
+         * @returns {Mixed} The initial value passed to the constructor until onNext is called; after which, the last value passed to onNext.
+         */
+        getValue(): T;
+    }
+
+    interface BehaviorSubjectStatic {
+        /**
+         *  Initializes a new instance of the BehaviorSubject class which creates a subject that caches its last value and starts with the specified value.
+         *  @param {Mixed} value Initial value sent to observers when no other value has been received by the subject yet.
+         */
+        new <T>(initialValue: T): BehaviorSubject<T>;
+    }
+
+    /**
+     *  Represents a value that changes over time.
+     *  Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+     */
+    export var BehaviorSubject: BehaviorSubjectStatic;
+
+    export interface ReplaySubject<T> extends Subject<T> { }
+
+    interface ReplaySubjectStatic {
+        /**
+         *  Initializes a new instance of the ReplaySubject class with the specified buffer size, window size and scheduler.
+         *  @param {Number} [bufferSize] Maximum element count of the replay buffer.
+         *  @param {Number} [windowSize] Maximum time length of the replay buffer.
+         *  @param {Scheduler} [scheduler] Scheduler the observers are invoked on.
+         */
+        new <T>(bufferSize?: number, window?: number, scheduler?: IScheduler): ReplaySubject<T>;
+    }
+
+    /**
+    * Represents an object that is both an observable sequence as well as an observer.
+    * Each notification is broadcasted to all subscribed and future observers, subject to buffer trimming policies.
+    */
+    export var ReplaySubject: ReplaySubjectStatic;
+
 }
 declare module "rx.core.binding" { export = Rx; }

--- a/ts/rx.d.ts
+++ b/ts/rx.d.ts
@@ -2422,4 +2422,4 @@ declare module Rx {
 }
 
 declare module "rx" { export = Rx; }
-declare module "rx" { export = Rx; }
+

--- a/ts/rx.es6.d.ts
+++ b/ts/rx.es6.d.ts
@@ -2419,4 +2419,4 @@ declare module Rx {
 }
 
 declare module "rx" { export = Rx; }
-declare module "rx" { export = Rx; }
+

--- a/ts/rx.time.d.ts
+++ b/ts/rx.time.d.ts
@@ -1,5 +1,115 @@
 declare module Rx {
 
+    export interface ObservableStatic {
+        /**
+         *  Returns an observable sequence that produces a value after each period.
+         *
+         * @example
+         *  1 - res = Rx.Observable.interval(1000);
+         *  2 - res = Rx.Observable.interval(1000, Rx.Scheduler.timeout);
+         *
+         * @param {Number} period Period for producing the values in the resulting sequence (specified as an integer denoting milliseconds).
+         * @param {Scheduler} [scheduler] Scheduler to run the timer on. If not specified, Rx.Scheduler.timeout is used.
+         * @returns {Observable} An observable sequence that produces a value after each period.
+         */
+        interval(period: number, scheduler?: IScheduler): Observable<number>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         *  Returns an observable sequence that produces a value after dueTime has elapsed and then after each period.
+         * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) at which to produce the first value.
+         * @param {Mixed} [periodOrScheduler]  Period to produce subsequent values (specified as an integer denoting milliseconds), or the scheduler to run the timer on. If not specified, the resulting timer is not recurring.
+         * @param {Scheduler} [scheduler]  Scheduler to run the timer on. If not specified, the timeout scheduler is used.
+         * @returns {Observable} An observable sequence that produces a value after due time has elapsed and then each period.
+         */
+        timer(dueTime: number, period: number, scheduler?: IScheduler): Observable<number>;
+        /**
+         *  Returns an observable sequence that produces a value after dueTime has elapsed and then after each period.
+         * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) at which to produce the first value.
+         * @param {Mixed} [periodOrScheduler]  Period to produce subsequent values (specified as an integer denoting milliseconds), or the scheduler to run the timer on. If not specified, the resulting timer is not recurring.
+         * @param {Scheduler} [scheduler]  Scheduler to run the timer on. If not specified, the timeout scheduler is used.
+         * @returns {Observable} An observable sequence that produces a value after due time has elapsed and then each period.
+         */
+        timer(dueTime: number, scheduler?: IScheduler): Observable<number>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
+        *
+        * @example
+        *  1 - res = Rx.Observable.delay(new Date());
+        *  2 - res = Rx.Observable.delay(new Date(), Rx.Scheduler.timeout);
+        *
+        *  3 - res = Rx.Observable.delay(5000);
+        *  4 - res = Rx.Observable.delay(5000, 1000, Rx.Scheduler.timeout);
+        * @memberOf Observable#
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) by which to shift the observable sequence.
+        * @param {Scheduler} [scheduler] Scheduler to run the delay timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(dueTime: Date, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
+        *
+        * @example
+        *  1 - res = Rx.Observable.delay(new Date());
+        *  2 - res = Rx.Observable.delay(new Date(), Rx.Scheduler.timeout);
+        *
+        *  3 - res = Rx.Observable.delay(5000);
+        *  4 - res = Rx.Observable.delay(5000, 1000, Rx.Scheduler.timeout);
+        * @memberOf Observable#
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) by which to shift the observable sequence.
+        * @param {Scheduler} [scheduler] Scheduler to run the delay timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Time shifts the observable sequence based on a subscription delay and a delay selector function for each element.
+        *
+        * @example
+        *  1 - res = source.delayWithSelector(function (x) { return Rx.Scheduler.timer(5000); }); // with selector only
+        *  1 - res = source.delayWithSelector(Rx.Observable.timer(2000), function (x) { return Rx.Observable.timer(x); }); // with delay and selector
+        *
+        * @param {Observable} [subscriptionDelay]  Sequence indicating the delay for the subscription to the source.
+        * @param {Function} delayDurationSelector Selector function to retrieve a sequence indicating the delay for each given element.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(delayDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+
+        /**
+        *  Time shifts the observable sequence based on a subscription delay and a delay selector function for each element.
+        *
+        * @example
+        *  1 - res = source.delayWithSelector(function (x) { return Rx.Scheduler.timer(5000); }); // with selector only
+        *  1 - res = source.delayWithSelector(Rx.Observable.timer(2000), function (x) { return Rx.Observable.timer(x); }); // with delay and selector
+        *
+        * @param {Observable} [subscriptionDelay]  Sequence indicating the delay for the subscription to the source.
+        * @param {Function} delayDurationSelector Selector function to retrieve a sequence indicating the delay for each given element.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(subscriptionDelay: Observable<number>, delayDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Ignores values from an observable sequence which are followed by another value before dueTime.
+        * @param {Number} dueTime Duration of the debounce period for each value (specified as an integer denoting milliseconds).
+        * @param {Scheduler} [scheduler]  Scheduler to run the debounce timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The debounced sequence.
+        */
+        debounce(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        * Ignores values from an observable sequence which are followed by another value within a computed throttle duration.
+        * @param {Function} durationSelector Selector function to retrieve a sequence indicating the throttle duration for each given element.
+        * @returns {Observable} The debounced sequence.
+        */
+        debounce(debounceDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Projects each element of an observable sequence into zero or more windows which are produced based on timing information.
@@ -77,6 +187,139 @@ declare module Rx {
         * @returns {Observable} An observable sequence with time interval information on values.
         */
         timeInterval(scheduler?: IScheduler): Observable<TimeInterval<T>>;
+    }
+
+    export interface Timestamp<T> {
+        value: T;
+        timestamp: number;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Records the timestamp for each value in an observable sequence.
+        *
+        * @example
+        *  1 - res = source.timestamp(); // produces { value: x, timestamp: ts }
+        *  2 - res = source.timestamp(Rx.Scheduler.default);
+        *
+        * @param {Scheduler} [scheduler]  Scheduler used to compute timestamps. If not specified, the default scheduler is used.
+        * @returns {Observable} An observable sequence with timestamp information on values.
+        */
+        timestamp(scheduler?: IScheduler): Observable<Timestamp<T>>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        sample(intervalOrSampler: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        sample<TSample>(sampler: Observable<TSample>, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        throttleLatest(interval: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        throttleLatest<TSample>(sampler: Observable<TSample>, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: Date, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: Date, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: number, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(timeoutdurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @param {Observable} other  Sequence to return in case of a timeout. If not provided, this is set to Observable.throwException().
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(timeoutdurationSelector: (item: T) => Observable<TTimeout>, other: Observable<T>): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Observable} [firstTimeout]  Observable sequence that represents the timeout for the first element. If not provided, this defaults to Observable.never().
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not provided, this is set to Observable.throwException().
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(firstTimeout: Observable<TTimeout>, timeoutdurationSelector: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
     }
 
     export interface ObservableStatic {
@@ -277,6 +520,16 @@ declare module Rx {
         * @returns {Observable} An observable sequence with the elements taken until the specified end time.
         */
         takeUntilWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an Observable that emits only the first item emitted by the source Observable during sequential time windows of a specified duration.
+        * @param {Number} windowDuration time to wait before emitting another item after emitting the last item
+        * @param {Scheduler} [scheduler] the Scheduler to use internally to manage the timers that handle timeout for each item. If not provided, defaults to Scheduler.timeout.
+        * @returns {Observable} An Observable that performs the throttle operation.
+        */
+        throttle(windowDuration: number, scheduler?: IScheduler): Observable<T>;
     }
 
 }

--- a/ts/rx.time.es6.d.ts
+++ b/ts/rx.time.es6.d.ts
@@ -1,5 +1,115 @@
 declare module Rx {
 
+    export interface ObservableStatic {
+        /**
+         *  Returns an observable sequence that produces a value after each period.
+         *
+         * @example
+         *  1 - res = Rx.Observable.interval(1000);
+         *  2 - res = Rx.Observable.interval(1000, Rx.Scheduler.timeout);
+         *
+         * @param {Number} period Period for producing the values in the resulting sequence (specified as an integer denoting milliseconds).
+         * @param {Scheduler} [scheduler] Scheduler to run the timer on. If not specified, Rx.Scheduler.timeout is used.
+         * @returns {Observable} An observable sequence that produces a value after each period.
+         */
+        interval(period: number, scheduler?: IScheduler): Observable<number>;
+    }
+
+    export interface ObservableStatic {
+        /**
+         *  Returns an observable sequence that produces a value after dueTime has elapsed and then after each period.
+         * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) at which to produce the first value.
+         * @param {Mixed} [periodOrScheduler]  Period to produce subsequent values (specified as an integer denoting milliseconds), or the scheduler to run the timer on. If not specified, the resulting timer is not recurring.
+         * @param {Scheduler} [scheduler]  Scheduler to run the timer on. If not specified, the timeout scheduler is used.
+         * @returns {Observable} An observable sequence that produces a value after due time has elapsed and then each period.
+         */
+        timer(dueTime: number, period: number, scheduler?: IScheduler): Observable<number>;
+        /**
+         *  Returns an observable sequence that produces a value after dueTime has elapsed and then after each period.
+         * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) at which to produce the first value.
+         * @param {Mixed} [periodOrScheduler]  Period to produce subsequent values (specified as an integer denoting milliseconds), or the scheduler to run the timer on. If not specified, the resulting timer is not recurring.
+         * @param {Scheduler} [scheduler]  Scheduler to run the timer on. If not specified, the timeout scheduler is used.
+         * @returns {Observable} An observable sequence that produces a value after due time has elapsed and then each period.
+         */
+        timer(dueTime: number, scheduler?: IScheduler): Observable<number>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
+        *
+        * @example
+        *  1 - res = Rx.Observable.delay(new Date());
+        *  2 - res = Rx.Observable.delay(new Date(), Rx.Scheduler.timeout);
+        *
+        *  3 - res = Rx.Observable.delay(5000);
+        *  4 - res = Rx.Observable.delay(5000, 1000, Rx.Scheduler.timeout);
+        * @memberOf Observable#
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) by which to shift the observable sequence.
+        * @param {Scheduler} [scheduler] Scheduler to run the delay timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(dueTime: Date, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
+        *
+        * @example
+        *  1 - res = Rx.Observable.delay(new Date());
+        *  2 - res = Rx.Observable.delay(new Date(), Rx.Scheduler.timeout);
+        *
+        *  3 - res = Rx.Observable.delay(5000);
+        *  4 - res = Rx.Observable.delay(5000, 1000, Rx.Scheduler.timeout);
+        * @memberOf Observable#
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) by which to shift the observable sequence.
+        * @param {Scheduler} [scheduler] Scheduler to run the delay timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Time shifts the observable sequence based on a subscription delay and a delay selector function for each element.
+        *
+        * @example
+        *  1 - res = source.delayWithSelector(function (x) { return Rx.Scheduler.timer(5000); }); // with selector only
+        *  1 - res = source.delayWithSelector(Rx.Observable.timer(2000), function (x) { return Rx.Observable.timer(x); }); // with delay and selector
+        *
+        * @param {Observable} [subscriptionDelay]  Sequence indicating the delay for the subscription to the source.
+        * @param {Function} delayDurationSelector Selector function to retrieve a sequence indicating the delay for each given element.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(delayDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+
+        /**
+        *  Time shifts the observable sequence based on a subscription delay and a delay selector function for each element.
+        *
+        * @example
+        *  1 - res = source.delayWithSelector(function (x) { return Rx.Scheduler.timer(5000); }); // with selector only
+        *  1 - res = source.delayWithSelector(Rx.Observable.timer(2000), function (x) { return Rx.Observable.timer(x); }); // with delay and selector
+        *
+        * @param {Observable} [subscriptionDelay]  Sequence indicating the delay for the subscription to the source.
+        * @param {Function} delayDurationSelector Selector function to retrieve a sequence indicating the delay for each given element.
+        * @returns {Observable} Time-shifted sequence.
+        */
+        delay(subscriptionDelay: Observable<number>, delayDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Ignores values from an observable sequence which are followed by another value before dueTime.
+        * @param {Number} dueTime Duration of the debounce period for each value (specified as an integer denoting milliseconds).
+        * @param {Scheduler} [scheduler]  Scheduler to run the debounce timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The debounced sequence.
+        */
+        debounce(dueTime: number, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        * Ignores values from an observable sequence which are followed by another value within a computed throttle duration.
+        * @param {Function} durationSelector Selector function to retrieve a sequence indicating the throttle duration for each given element.
+        * @returns {Observable} The debounced sequence.
+        */
+        debounce(debounceDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+    }
+
     export interface Observable<T> {
         /**
         *  Projects each element of an observable sequence into zero or more windows which are produced based on timing information.
@@ -77,6 +187,139 @@ declare module Rx {
         * @returns {Observable} An observable sequence with time interval information on values.
         */
         timeInterval(scheduler?: IScheduler): Observable<TimeInterval<T>>;
+    }
+
+    export interface Timestamp<T> {
+        value: T;
+        timestamp: number;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Records the timestamp for each value in an observable sequence.
+        *
+        * @example
+        *  1 - res = source.timestamp(); // produces { value: x, timestamp: ts }
+        *  2 - res = source.timestamp(Rx.Scheduler.default);
+        *
+        * @param {Scheduler} [scheduler]  Scheduler used to compute timestamps. If not specified, the default scheduler is used.
+        * @returns {Observable} An observable sequence with timestamp information on values.
+        */
+        timestamp(scheduler?: IScheduler): Observable<Timestamp<T>>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        sample(intervalOrSampler: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        sample<TSample>(sampler: Observable<TSample>, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        throttleLatest(interval: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Samples the observable sequence at each interval.
+        *
+        * @example
+        *  1 - res = source.sample(sampleObservable); // Sampler tick sequence
+        *  2 - res = source.sample(5000); // 5 seconds
+        *  2 - res = source.sample(5000, Rx.Scheduler.timeout); // 5 seconds
+        *
+        * @param {Mixed} intervalOrSampler Interval at which to sample (specified as an integer denoting milliseconds) or Sampler Observable.
+        * @param {Scheduler} [scheduler]  Scheduler to run the sampling timer on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} Sampled observable sequence.
+        */
+        throttleLatest<TSample>(sampler: Observable<TSample>, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: Date, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: Date, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: number, scheduler?: IScheduler): Observable<T>;
+        /**
+        *  Returns the source observable sequence or the other observable sequence if dueTime elapses.
+        * @param {Number} dueTime Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) when a timeout occurs.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not specified, a timeout error throwing sequence will be used.
+        * @param {Scheduler} [scheduler]  Scheduler to run the timeout timers on. If not specified, the timeout scheduler is used.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout(dueTime: number, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(timeoutdurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @param {Observable} other  Sequence to return in case of a timeout. If not provided, this is set to Observable.throwException().
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(timeoutdurationSelector: (item: T) => Observable<TTimeout>, other: Observable<T>): Observable<T>;
+
+        /**
+        *  Returns the source observable sequence, switching to the other observable sequence if a timeout is signaled.
+        * @param {Observable} [firstTimeout]  Observable sequence that represents the timeout for the first element. If not provided, this defaults to Observable.never().
+        * @param {Function} timeoutDurationSelector Selector to retrieve an observable sequence that represents the timeout between the current element and the next element.
+        * @param {Observable} [other]  Sequence to return in case of a timeout. If not provided, this is set to Observable.throwException().
+        * @returns {Observable} The source sequence switching to the other sequence in case of a timeout.
+        */
+        timeout<TTimeout>(firstTimeout: Observable<TTimeout>, timeoutdurationSelector: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
     }
 
     export interface ObservableStatic {
@@ -277,6 +520,16 @@ declare module Rx {
         * @returns {Observable} An observable sequence with the elements taken until the specified end time.
         */
         takeUntilWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
+    }
+
+    export interface Observable<T> {
+        /**
+        * Returns an Observable that emits only the first item emitted by the source Observable during sequential time windows of a specified duration.
+        * @param {Number} windowDuration time to wait before emitting another item after emitting the last item
+        * @param {Scheduler} [scheduler] the Scheduler to use internally to manage the timers that handle timeout for each item. If not provided, defaults to Scheduler.timeout.
+        * @returns {Observable} An Observable that performs the throttle operation.
+        */
+        throttle(windowDuration: number, scheduler?: IScheduler): Observable<T>;
     }
 
 }


### PR DESCRIPTION
rebuild-ts task would wrongly exclude typings included in the rx.lite.d.ts
file. For instance would rx.time.d.ts only receive the typings not
included in rx.lite.d.ts.

As it was, I could only use either rx.lite.d.ts or rx.all.d.ts. However,
I use a subset with rx.d.ts, rx.binding.ts and rx.time.d.ts. This fix
makes it possible to do that. Instead of excluding typings included in
lite, the rebuild-ts task now correctly excludes typings included in main
(rx.d.ts). The original behaviour is kept if lite typings are built. I
believe this is the correct behaviour, and it works nicely in my setup. I
can now use a subset of the typings and the original lite typings are the 
same as before.

I've also fixed the declare module output of rx.d.ts. It would previously
add the declare module "rx" line twice, resulting in a compiler error when
included in a project.