### PR TITLE
use correct parameter name in example

### DIFF
--- a/doc/howdoi/wrap.md
+++ b/doc/howdoi/wrap.md
@@ -78,7 +78,7 @@ And now we can consume the geolocation such as:
 var source = watchPosition();
 
 var subscription = source.subscribe(
-    function (pos) {
+    function (position) {
         console.log('Next:' + position.coords.latitude + ',' + position.coords.longitude);
     },
     function (err) {


### PR DESCRIPTION
parameter was previously `pos` but referenced inside the example as `position`. updated example code accordingly.