### PR TITLE
Fixing README 404s

### DIFF
--- a/doc/gettingstarted/which-instance.md
+++ b/doc/gettingstarted/which-instance.md
@@ -161,7 +161,7 @@ Use this page to find the instance operator implemented by the [`Observable`](ht
     <tr>
         <td rowspan="2">I want to know if a condition is satisfied</td>
         <td colspan="2">by any of its values</td>
-        <td><a href="https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/any.md">any/some</a></td>
+        <td><a href="https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/some.md">any/some</a></td>
     </tr>
     <tr>
         <td colspan="2">by all of its values</td>

--- a/doc/libraries/lite/rx.lite.aggregates.md
+++ b/doc/libraries/lite/rx.lite.aggregates.md
@@ -18,7 +18,7 @@ File Dependencies:
 ## Included Observable Operators ##
 
 ### `Observable Instance Methods`
-- [`aggregate`](../../api/core/operators/aggregate.md)
+- [`aggregate`](../../api/core/operators/reduce.md)
 - [`all`](../../api/core/operators/every.md)
 - [`any`](../../api/core/operators/some.md)
 - [`average`](../../api/core/operators/average.md)

--- a/doc/libraries/main/rx.aggregates.md
+++ b/doc/libraries/main/rx.aggregates.md
@@ -22,7 +22,7 @@ NuGet Dependencies:
 ## Included Observable Operators ##
 
 ### `Observable Instance Methods`
-- [`aggregate`](../../api/core/operators/aggregate.md)
+- [`aggregate`](../../api/core/operators/reduce.md)
 - [`all`](../../api/core/operators/every.md)
 - [`any`](../../api/core/operators/some.md)
 - [`average`](../../api/core/operators/average.md)

--- a/doc/libraries/main/rx.complete.md
+++ b/doc/libraries/main/rx.complete.md
@@ -66,11 +66,11 @@ NuGet Packages:
 - [`zip`](../../api/core/operators/zip.md)
 
 ### `Observable Instance Methods`
-- [`aggregate`](../../api/core/operators/aggregate.md)
-- [`all`](../../api/core/operators/all.md)
+- [`aggregate`](../../api/core/operators/reduce.md)
+- [`all`](../../api/core/operators/every.md)
 - [`amb`](../../api/core/operators/ambproto.md)
 - [`and`](../../api/core/operators/and.md)
-- [`any`](../../api/core/operators/any.md)
+- [`any`](../../api/core/operators/some.md)
 - [`asObservable`](../../api/core/operators/asobservable.md)
 - [`average`](../../api/core/operators/average.md)
 - [`buffer`](../../api/core/operators/buffer.md)

--- a/modules/rx-lite-aggregates-compat/readme.md
+++ b/modules/rx-lite-aggregates-compat/readme.md
@@ -30,7 +30,7 @@ var Rx = require('rx-lite-aggregates-compat');
 ## Included Observable Operators ##
 
 ### `Observable Instance Methods`
-- [`aggregate`](../../doc/api/core/operators/aggregate.md)
+- [`aggregate`](../../doc/api/core/operators/reduce.md)
 - [`all`](../../doc/api/core/operators/every.md)
 - [`any`](../../doc/api/core/operators/some.md)
 - [`average`](../../doc/api/core/operators/average.md)

--- a/modules/rx-lite-aggregates/readme.md
+++ b/modules/rx-lite-aggregates/readme.md
@@ -30,7 +30,7 @@ var Rx = require('rx-lite-aggregates');
 ## Included Observable Operators ##
 
 ### `Observable Instance Methods`
-- [`aggregate`](../../doc/api/core/operators/aggregate.md)
+- [`aggregate`](../../doc/api/core/operators/reduce.md)
 - [`all`](../../doc/api/core/operators/every.md)
 - [`any`](../../doc/api/core/operators/some.md)
 - [`average`](../../doc/api/core/operators/average.md)


### PR DESCRIPTION
- `aggregate` now links to `reduce`
- `all` links to `every`
- `any` links to `some`