### PR TITLE
Fix syntax errors in documentation

### DIFF
--- a/doc/api/config/readme.md
+++ b/doc/api/config/readme.md
@@ -45,8 +45,8 @@ We can do this by setting the `Rx.config.useNativeEvents` flag to `true`.
 Rx.config.useNativeEvents = true;
 
 Rx.Observable.fromEvent(document, 'mousemove')
-  .subscribe(e) {
+  .subscribe(function (e) {
     console.log('ClientX: %d, ClientY: %d', e.clientX, e.clientY);
-  }
+  });
 ```
 * * *

--- a/doc/api/core/notification.md
+++ b/doc/api/core/notification.md
@@ -18,7 +18,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');
@@ -68,7 +68,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');
@@ -101,7 +101,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');
@@ -141,7 +141,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');
@@ -214,7 +214,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');
@@ -232,7 +232,7 @@ var subscription = source.subscribe(
     console.log('Next: %s', x);
   },
   function (err) {
-    console.log('Error: %s', err;
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');

--- a/doc/api/core/operators/and.md
+++ b/doc/api/core/operators/and.md
@@ -14,7 +14,7 @@ Propagates the observable sequence that reacts first.
 // Choice of either plan, the first set of timers or second set
 var source = Rx.Observable.when(
     Rx.Observable.timer(200).and(Rx.Observable.timer(300)).thenDo(function (x, y) { return 'first'; }),
-    Rx.Observable.timer(400).and(Rx.Observable.timer(500)).thenDo(function (x, y) { return 'second'; }),
+    Rx.Observable.timer(400).and(Rx.Observable.timer(500)).thenDo(function (x, y) { return 'second'; })
 );
 
 var subscription = source.subscribe(

--- a/doc/api/core/operators/distinct.md
+++ b/doc/api/core/operators/distinct.md
@@ -18,7 +18,7 @@ var source = Rx.Observable.of(42, 24, 42, 24)
 
 var subscription = source.subscribe(
   function (x) {
-    console.log('Next: %s', x;
+    console.log('Next: %s', x);
   },
   function (err) {
     console.log('Error: %s', err);
@@ -37,7 +37,7 @@ var source = Rx.Observable.of({value: 42}, {value: 24}, {value: 42}, {value: 24}
 
 var subscription = source.subscribe(
   function (x) {
-    console.log('Next: %s', x;
+    console.log('Next: %s', x);
   },
   function (err) {
     console.log('Error: %s', err);

--- a/doc/api/core/operators/doonerror.md
+++ b/doc/api/core/operators/doonerror.md
@@ -16,7 +16,7 @@ This method can be used for debugging, logging, etc. of query behavior by interc
 #### Example
 ```js
 /* Using a function */
-var source = Rx.Observable.throw(new Error());
+var source = Rx.Observable.throw(new Error())
   .doOnError(
     function (err) { console.log('Do Error: %s', err); }
   );
@@ -37,7 +37,7 @@ var subscription = source.subscribe(
 
 /* Using a thisArg */
 
-var source = Rx.Observable.throw(new Error());
+var source = Rx.Observable.throw(new Error())
   .doOnError(
     function (err) { this.log('Do Error: %s', err); },
     console

--- a/doc/api/core/operators/fromeventpattern.md
+++ b/doc/api/core/operators/fromeventpattern.md
@@ -32,7 +32,7 @@ var subscription = source.subscribe(
     console.log('Next: Clicked!');
   },
   function (err) {
-    console.log('Error: %s' err);
+    console.log('Error: %s', err);
   },
   function () {
     console.log('Completed');

--- a/doc/api/core/operators/pairs.md
+++ b/doc/api/core/operators/pairs.md
@@ -39,7 +39,7 @@ var subscription = source.subscribe(
   ```
 
 ES6 makes for an even nicer experience such as:
-```js
+```es6
 let obj = {
   foo: 42,
   bar: 56,

--- a/doc/api/core/operators/partition.md
+++ b/doc/api/core/operators/partition.md
@@ -16,7 +16,7 @@ Returns two observables which partition the observations of the source by the gi
 #### Example
 
 An example using ES6 syntax:
-```js
+```es6
 let [odds, evens] = Rx.Observable.range(0, 10)
   .partition(x => x % 2 === 0);
 

--- a/doc/api/core/operators/subscribeoncompleted.md
+++ b/doc/api/core/operators/subscribeoncompleted.md
@@ -28,7 +28,7 @@ var source = Rx.Observable.range(0, 3);
 var subscription = source.subscribeOnCompleted(
   function (err) {
     this.log('Completed');
-  }}, console);
+  }, console);
 
 // => Completed
 ```

--- a/doc/api/core/operators/subscribeonerror.md
+++ b/doc/api/core/operators/subscribeonerror.md
@@ -28,7 +28,7 @@ var source = Rx.Observable.throw(new Error());
 var subscription = source.subscribeOnError(
   function (err) {
     this.log('Error: %s', err);
-  }}, console);
+  }, console);
 
 // => Error: Error
 ```

--- a/doc/api/core/operators/subscribeonnext.md
+++ b/doc/api/core/operators/subscribeonnext.md
@@ -30,7 +30,7 @@ var source = Rx.Observable.range(0, 3)
 var subscription = source.subscribeOnNext(
   function (x) {
     this.log('Next: %s', x);
-  }}, console);
+  }, console);
 
 // => Next: 0
 // => Next: 1

--- a/doc/api/core/operators/topromise.md
+++ b/doc/api/core/operators/topromise.md
@@ -10,7 +10,7 @@ Converts an Observable sequence to a ES2015 compliant promise.
 *(`Promise`)*: An ES2015 compliant promise which contains the last value from the Observable sequence. If the Observable sequence is in error, then the Promise will be in the rejected stage. If the sequence is empty, the Promise will not resolve.
 
 #### Example
-```js
+```es6
 /* Using normal ES2015 */
 let source = Rx.Observable
   .just(42)

--- a/doc/api/core/operators/zip.md
+++ b/doc/api/core/operators/zip.md
@@ -71,7 +71,7 @@ var range = Rx.Observable.range(0, 5);
 var source = Observable.zip(
   Promise.resolve(0),
   Promise.resolve(1),
-  Rx.Observable.return(2)
+  Rx.Observable.return(2),
   function (s1, s2, s3) {
     return s1 + ':' + s2 + ':' + s3;
   }

--- a/doc/api/testing/testscheduler.md
+++ b/doc/api/testing/testscheduler.md
@@ -307,7 +307,7 @@ scheduler.scheduleAbsolute(100, function () {
     },
     res.onError.bind(res),
     res.onCompleted.bind(res)
-  );
+  ));
 });
 
 scheduler.start();

--- a/doc/designguidelines/readme.md
+++ b/doc/designguidelines/readme.md
@@ -894,7 +894,7 @@ Rx.Observable.prototype.map = function (selector, thisArg) {
       observer.onError.bind(observer),
       observer.onCompleted.bind(observer)
     );
-  };
+  });
 };
 ```
 

--- a/doc/gettingstarted/errors.md
+++ b/doc/gettingstarted/errors.md
@@ -154,7 +154,7 @@ var source = get('url').retryWhen(
   function (attempts) {
     return attempts
       .zip(Rx.Observable.range(1, 3), function (_, i) { return i })
-      .flatMap(function (i)) {
+      .flatMap(function (i) {
         console.log('delay retry by ' + i + ' second(s)');
         return Rx.Observable.timer(i * 1000);
       });

--- a/doc/howdoi/angular.md
+++ b/doc/howdoi/angular.md
@@ -89,11 +89,11 @@ Using the Reactive Extensions for JavaScript, we can also integrate using the `R
 ```js
 // Query data
 var observable = Rx.Observable.fromPromise(
-	$http(
+	$http({
 		method: 'GET',
 		url: 'someurl',
 		params: { searchString: $scope.searchString }
-	)
+	})
 );
 
 // Subscribe to data and update UI

--- a/doc/mapping/bacon.js/whyrx.md
+++ b/doc/mapping/bacon.js/whyrx.md
@@ -239,12 +239,12 @@ var results = scheduler.startWithCreate(function () {
 // Some custom collection assertion for values
 collectionAssert.assertEqual(results.messages, [
   Rx.ReactiveTest.onNext(201, 2),
-  Rx.ReactiveTest.onCompleted(202);
+  Rx.ReactiveTest.onCompleted(202)
 ]);
 
 // Some custom collection assertion for subscriptions
 collectionAssert.assertEqual(xs.subscriptions, [
-  Rx.ReactiveTest.subscribe(200, 202);
+  Rx.ReactiveTest.subscribe(200, 202)
 ])
 ```
 
@@ -264,7 +264,7 @@ getStockData().forEach(function (stock) {
 });
 
 // Calculate with the data
-source.groupBy(function (stock) { return stock.symbol };)
+source.groupBy(function (stock) { return stock.symbol; })
   /* Do something with the data */
   .subscribe(function (info) {
     // Process the data
@@ -279,7 +279,7 @@ In our applications, we consume a lot of data from external sources.  But, what 
 
 RxJS has a rather large surface area, so we give you the ability to build RxJS with only the things you want and none of the things you don't via the [`rx-cli`](https://www.npmjs.org/package/rx-cli) project.  For example, we can build a `compat` version of RxJS with only the `map`, `flatMap`, `takeUntil`, and `fromEvent` methods, which keeps your RxJS version lean and mean.
 
-```js
+```bash
 rx --lite --compat --methods map,flatmap,takeuntil,fromevent
 ```
 

--- a/doc/mapping/highland/whyrx.md
+++ b/doc/mapping/highland/whyrx.md
@@ -232,12 +232,12 @@ var results = scheduler.startWithCreate(function () {
 // Some custom collection assertion for values
 collectionAssert.assertEqual(results.messages, [
   Rx.ReactiveTest.onNext(201, 2),
-  Rx.ReactiveTest.onCompleted(202);
+  Rx.ReactiveTest.onCompleted(202)
 ]);
 
 // Some custom collection assertion for subscriptions
 collectionAssert.assertEqual(xs.subscriptions, [
-  Rx.ReactiveTest.subscribe(200, 202);
+  Rx.ReactiveTest.subscribe(200, 202)
 ])
 ```
 
@@ -257,7 +257,7 @@ getStockData().forEach(function (stock) {
 });
 
 // Calculate with the data
-source.groupBy(function (stock) { return stock.symbol };)
+source.groupBy(function (stock) { return stock.symbol })
   /* Do something with the data */
   .subscribe(function (info) {
     // Process the data
@@ -290,7 +290,7 @@ pauser.resume();
 
 RxJS has a rather large surface area, so we give you the ability to build RxJS with only the things you want and none of the things you don't via the [`rx-cli`](https://www.npmjs.org/package/rx-cli) project.  For example, we can build a `compat` version of RxJS with only the `map`, `flatMap`, `takeUntil`, and `fromEvent` methods, which keeps your RxJS version lean and mean.
 
-```js
+```bash
 rx --lite --compat --methods map,flatmap,takeuntil,fromevent
 ```
 


### PR DESCRIPTION
I've written a tool that executes all of the `js` examples in the documentation and reports errors. 

I'm hoping to contribute the tool as something that can be used as part of the CI build step. However, it's not quite ready for that yet. (If you're interested, [check it out](https://github.com/Widdershin/RxJS/blob/doctest/doctest.js), currently usable with `npm run doctest`).

So I figured I would start by fixing all of the syntax errors that it's reported. I also changed the language of several examples, as `doctest` does not run `es6` or `bash` examples.

The `es6` language displays syntax highlighting on Github correctly, so there is no impact to the examples.