### PR TITLE
Removing unnecessary set to scope.name

### DIFF
--- a/doc/howdoi/angular.md
+++ b/doc/howdoi/angular.md
@@ -20,8 +20,6 @@ scope.$watch('name', function(newValue, oldValue) {
   scope.newValue = newValue;
 });
 
-scope.name = 'RxJS';
-
 // Process All the Watchers
 scope.$digest();
 


### PR DESCRIPTION
There are two scope.name sets. One is unecessary.