### PR TITLE
some() predicate is not optional

### DIFF
--- a/doc/api/core/operators/some.md
+++ b/doc/api/core/operators/some.md
@@ -1,10 +1,10 @@
 ### `Rx.Observable.prototype.some([predicate], [thisArg])` ###
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/some.js "View in source")
 
-Determines whether any element of an observable sequence satisfies a condition if present, else if any items are in the sequence. There is an alias to this function called `some`.
+Determines whether any element of an observable sequence satisfies a condition if present, else if any items are in the sequence.
 
 #### Arguments
-1. `[predicate]` *(`Function`)*: A function to test each element for a condition.
+1. `predicate` *(`Function`)*: A function to test each element for a condition.
 2. `[thisArg]` *(`Any`)*: Object to use as this when executing callback.
 
 #### Returns
@@ -12,24 +12,6 @@ Determines whether any element of an observable sequence satisfies a condition i
 
 #### Example
 ```js
-// Without a predicate
-var source = Rx.Observable.empty().some();
-
-var subscription = source.subscribe(
-  function (x) {
-    console.log('Next: %s', x);
-  },
-  function (err) {
-    console.log('Error: %s', err);
-  },
-  function () {
-    console.log('Completed');
-  });
-
-// => Next: false
-// => Completed
-
-// With a predicate
 var source = Rx.Observable.of(1,2,3,4,5)
   .some(function (x) { return x % 2 === 0; });
 


### PR DESCRIPTION
Apparently the predicate is not optional for the `some()` operator, as it throws "TypeError: fn must be a function" if you try to omit a predicate with a source that actually produces values. Removing example that shows using `some()` without a predicate on an empty source since that seems pointless - unless I'm missing something - and potentially misleading.

Either this or `some()` should default the predicate to `Rx.helpers.identity`.

Also removing sentence about this operator having an alias called `some`, since this *is* `some`.