### PR TITLE
Update testing documentation

### DIFF
--- a/doc/api/testing/reactivetest.md
+++ b/doc/api/testing/reactivetest.md
@@ -45,7 +45,7 @@ var res = scheduler.startScheduler(function () {
 });
 
 // Write custom assertion
-collectionAssert(res, [
+collectionAssert.assertEqual(res.messages, [
     onCompleted(260)
 ]);
 ```
@@ -86,7 +86,7 @@ var res = scheduler.startScheduler(function () {
 });
 
 // Write custom assertion
-collectionAssert(res, [
+collectionAssert.assertEqual(res.messages, [
 
     // Using a predicate
     onError(201, function (e) { return e.message === 'woops'; })
@@ -127,7 +127,7 @@ var res = scheduler.startScheduler(function () {
 });
 
 // Write custom assertion
-collectionAssert(res, [
+collectionAssert.assertEqual(res.messages, [
 
     // Using a predicate
     onNext(201, function (x) { return x === 42; })

--- a/doc/api/testing/reactivetest.md
+++ b/doc/api/testing/reactivetest.md
@@ -37,16 +37,16 @@ var onCompleted = Rx.ReactiveTest.onCompleted;
 var scheduler = new Rx.TestScheduler();
 
 var xs = scheduler.createHotObservable(
-    onCompleted(260)
+  onCompleted(260)
 );
 
 var res = scheduler.startScheduler(function () {
-    return xs.map(function (x) { return x; });
+  return xs.map(function (x) { return x; });
 });
 
 // Write custom assertion
 collectionAssert.assertEqual(res.messages, [
-    onCompleted(260)
+  onCompleted(260)
 ]);
 ```
 
@@ -88,8 +88,8 @@ var res = scheduler.startScheduler(function () {
 // Write custom assertion
 collectionAssert.assertEqual(res.messages, [
 
-    // Using a predicate
-    onError(201, function (e) { return e.message === 'woops'; })
+  // Using a predicate
+  onError(201, function (e) { return e.message === 'woops'; })
 ]);
 ```
 
@@ -129,8 +129,8 @@ var res = scheduler.startScheduler(function () {
 // Write custom assertion
 collectionAssert.assertEqual(res.messages, [
 
-    // Using a predicate
-    onNext(201, function (x) { return x === 42; })
+  // Using a predicate
+  onNext(201, function (x) { return x === 42; })
 ]);
 ```
 
@@ -183,9 +183,9 @@ Default virtual time used to dispose subscriptions in unit tests.  This has a va
 var scheduler = new Rx.TestScheduler();
 
 var xs = scheduler.createHotObservable(
-    Rx.ReactiveTest.onNext(201, 42),
-    Rx.ReactiveTest.onNext(202, 56),
-    Rx.ReactiveTest.onCompleted(203)
+  Rx.ReactiveTest.onNext(201, 42),
+  Rx.ReactiveTest.onNext(202, 56),
+  Rx.ReactiveTest.onCompleted(203)
 );
 
 var res = scheduler.startScheduler(
@@ -215,9 +215,9 @@ Default virtual time used to subscribe to observable sequences in unit tests.  T
 var scheduler = new Rx.TestScheduler();
 
 var xs = scheduler.createHotObservable(
-    Rx.ReactiveTest.onNext(201, 42),
-    Rx.ReactiveTest.onNext(202, 56),
-    Rx.ReactiveTest.onCompleted(203)
+  Rx.ReactiveTest.onNext(201, 42),
+  Rx.ReactiveTest.onNext(202, 56),
+  Rx.ReactiveTest.onCompleted(203)
 );
 
 var res = scheduler.startScheduler(

--- a/doc/api/testing/reactivetest.md
+++ b/doc/api/testing/reactivetest.md
@@ -40,7 +40,7 @@ var xs = scheduler.createHotObservable(
     onCompleted(260)
 );
 
-var res = scheduler.startWithCreate(function () {
+var res = scheduler.startScheduler(function () {
     return xs.map(function (x) { return x; });
 });
 
@@ -81,8 +81,8 @@ var xs = scheduler.createHotObservable(
     onError(201, ex)
 );
 
-var res = scheduler.startWithCreate(function () {
-    return xs.map(function (x) { return x; });
+var res = scheduler.startScheduler(function () {
+  return xs.map(function (x) { return x; });
 });
 
 // Write custom assertion
@@ -122,8 +122,8 @@ var xs = scheduler.createHotObservable(
     onNext(201, 42)
 );
 
-var res = scheduler.startWithCreate(function () {
-    return xs.map(function (x) { return x; });
+var res = scheduler.startScheduler(function () {
+  return xs.map(function (x) { return x; });
 });
 
 // Write custom assertion
@@ -153,16 +153,16 @@ Default virtual time used for creation of observable sequences in unit tests.  T
 var scheduler = new Rx.TestScheduler();
 
 var xs = scheduler.createHotObservable(
-    Rx.ReactiveTest.onNext(201, 42),
-    Rx.ReactiveTest.onNext(202, 56),
-    Rx.ReactiveTest.onCompleted(203)
+  Rx.ReactiveTest.onNext(201, 42),
+  Rx.ReactiveTest.onNext(202, 56),
+  Rx.ReactiveTest.onCompleted(203)
 );
 
-var res = scheduler.startWithTiming(
-    function () { return xs.map(function (x) { return x; })},
-    Rx.ReactiveTest.created,
-    Rx.ReactiveTest.subscribed,
-    Rx.ReactiveTest.disposed
+var res = scheduler.startScheduler(
+  function () { return xs.map(function (x) { return x; })},
+  Rx.ReactiveTest.created,
+  Rx.ReactiveTest.subscribed,
+  Rx.ReactiveTest.disposed
 );
 ```
 
@@ -188,11 +188,13 @@ var xs = scheduler.createHotObservable(
     Rx.ReactiveTest.onCompleted(203)
 );
 
-var res = scheduler.startWithTiming(
-    function () { return xs.map(function (x) { return x; })},
-    Rx.ReactiveTest.created,
-    Rx.ReactiveTest.subscribed,
-    Rx.ReactiveTest.disposed
+var res = scheduler.startScheduler(
+  function () { return xs.map(function (x) { return x; })},
+  {
+    created: Rx.ReactiveTest.created,
+    subscribed: Rx.ReactiveTest.subscribed,
+    disposed: Rx.ReactiveTest.disposed
+  }
 );
 ```
 
@@ -218,11 +220,8 @@ var xs = scheduler.createHotObservable(
     Rx.ReactiveTest.onCompleted(203)
 );
 
-var res = scheduler.startWithTiming(
-    function () { return xs.map(function (x) { return x; })},
-    Rx.ReactiveTest.created,
-    Rx.ReactiveTest.subscribed,
-    Rx.ReactiveTest.disposed
+var res = scheduler.startScheduler(
+  function () { return xs.map(function (x) { return x; })}
 );
 ```
 

--- a/doc/api/testing/testscheduler.md
+++ b/doc/api/testing/testscheduler.md
@@ -13,7 +13,7 @@ function createMessage(expected, actual) {
 
 // Using QUnit testing for assertions
 var collectionAssert = {
-  assertEqual: function (expected, actual) {
+  assertEqual: function (actual, expected) {
     var comparer = Rx.internals.isEqual, isOk = true;
 
     if (expected.length !== actual.length) {
@@ -93,17 +93,17 @@ Creates a new virtual time test scheduler.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onCompleted = Rx.ReactiveTest.onCompleted,
-    subscribe = Rx.ReactiveTest.subscribe;
+  onCompleted = Rx.ReactiveTest.onCompleted,
+  subscribe = Rx.ReactiveTest.subscribe;
 
 var scheduler = new Rx.TestScheduler();
 
 // Create hot observable which will start firing
 var xs = scheduler.createHotObservable(
-    onNext(150, 1),
-    onNext(210, 2),
-    onNext(220, 3),
-    onCompleted(230)
+  onNext(150, 1),
+  onNext(210, 2),
+  onNext(220, 3),
+  onCompleted(230)
 );
 
 // Note we'll start at 200 for subscribe, hence missing the 150 mark
@@ -162,33 +162,33 @@ Creates a cold observable using the specified timestamped notification messages.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onCompleted = Rx.ReactiveTest.onCompleted
-    subscribe = Rx.ReactiveTest.subscribe;
+  onCompleted = Rx.ReactiveTest.onCompleted
+  subscribe = Rx.ReactiveTest.subscribe;
 
 var scheduler = new Rx.TestScheduler();
 
 // Create cold observable with offset from subscribe time
 var xs = scheduler.createColdObservable(
-    onNext(150, 1),
-    onNext(200, 2),
-    onNext(250, 3),
-    onCompleted(300)
+  onNext(150, 1),
+  onNext(200, 2),
+  onNext(250, 3),
+  onCompleted(300)
 );
 
 // Note we'll start at 200 for subscribe
 var res = scheduler.startScheduler(function () {
-    return xs.filter(function (x) { return x % 2 === 0; });
+  return xs.filter(function (x) { return x % 2 === 0; });
 });
 
 // Implement collection assertion
 collectionAssert.assertEqual(res.messages, [
-    onNext(400, 2),
-    onCompleted(500)
+  onNext(400, 2),
+  onCompleted(500)
 ]);
 
 // Check for subscribe/unsubscribe
 collectionAssert.assertEqual(xs.subscriptions, [
-    subscribe(200, 500)
+  subscribe(200, 500)
 ]);
 ```
 
@@ -228,33 +228,33 @@ Creates a hot observable using the specified timestamped notification messages.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onCompleted = Rx.ReactiveTest.onCompleted;
+  onCompleted = Rx.ReactiveTest.onCompleted;
 
 var scheduler = new Rx.TestScheduler();
 
 // Create hot observable which will start firing
 var xs = scheduler.createHotObservable(
-    onNext(150, 1),
-    onNext(210, 2),
-    onNext(220, 3),
-    onCompleted(230)
+  onNext(150, 1),
+  onNext(210, 2),
+  onNext(220, 3),
+  onCompleted(230)
 );
 
 // Note we'll start at 200 for subscribe, hence missing the 150 mark
 var res = scheduler.startScheduler(function () {
-    return xs.map(function (x) { return x * x });
+  return xs.map(function (x) { return x * x });
 });
 
 // Implement collection assertion
 collectionAssert.assertEqual(res.messages, [
-    onNext(210, 4),
-    onNext(220, 9),
-    onCompleted(230)
+  onNext(210, 4),
+  onNext(220, 9),
+  onCompleted(230)
 ]);
 
 // Check for subscribe/unsubscribe
 collectionAssert.assertEqual(xs.subscriptions, [
-    subscribe(200, 230)
+  subscribe(200, 230)
 ]);
 ```
 
@@ -355,8 +355,8 @@ Creates a rejected promise with the given reason and ticks.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onError = Rx.ReactiveTest.onError,
-    onCompleted = Rx.ReactiveTest.onCompleted;
+  onError = Rx.ReactiveTest.onError,
+  onCompleted = Rx.ReactiveTest.onCompleted;
 
 var scheduler = new Rx.TestScheduler();
 
@@ -413,8 +413,8 @@ Creates a resolved promise with the given value and ticks.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onError = Rx.ReactiveTest.onError,
-    onCompleted = Rx.ReactiveTest.onCompleted;
+  onError = Rx.ReactiveTest.onError,
+  onCompleted = Rx.ReactiveTest.onCompleted;
 
 var scheduler = new Rx.TestScheduler();
 

--- a/doc/api/testing/testscheduler.md
+++ b/doc/api/testing/testscheduler.md
@@ -162,7 +162,8 @@ Creates a cold observable using the specified timestamped notification messages.
 #### Example
 ```js
 var onNext = Rx.ReactiveTest.onNext,
-    onCompleted = Rx.ReactiveTest.onCompleted;
+    onCompleted = Rx.ReactiveTest.onCompleted
+    subscribe = Rx.ReactiveTest.subscribe;
 
 var scheduler = new Rx.TestScheduler();
 
@@ -299,8 +300,8 @@ var xs = Rx.Observable.return(42, scheduler);
 
 var res = scheduler.createObserver();
 
-scheduler.scheduleAbsolute(100, function () {
-  d.setDisposable(xs.subscribe(
+scheduler.scheduleAbsolute(null, 100, function () {
+  return d.setDisposable(xs.subscribe(
     function (x) {
       d.dispose();
       res.onNext(x);

--- a/doc/gettingstarted/testing.md
+++ b/doc/gettingstarted/testing.md
@@ -13,7 +13,7 @@ After the sequence has completed, we use can define method such as `collectionAs
 In the same way, you can use that same defined method such as our `collectionAssert.assertEqual` below to confirm that subscriptions indeed happened at expected times.  It is easy to wrap this for your favorite unit testing framework whether it is QUnit, Mocha, Jasmine, etc.  In this example, we'll write a quick wrapper for QUnit.
 
 ```js
-function createMessage(actual, expected) {
+function createMessage(expected, actual) {
     return 'Expected: [' + expected.toString() + ']\r\nActual: [' + actual.toString() + ']';
 }
 
@@ -56,7 +56,7 @@ test('buffer should join strings', function () {
         onCompleted(500)
     );
 
-    var results = scheduler.startWithTiming(
+    var results = scheduler.startScheduler(
         function () {
             return input.buffer(function () {
                 return input.debounce(100, scheduler);
@@ -65,9 +65,11 @@ test('buffer should join strings', function () {
                 return b.join(',');
             });
         },
-        50,  // created
-        150, // subscribed
-        600  // disposed
+        {
+          created: 50,
+          subscribed: 150,
+          disposed: 600
+        }
     );
 
     collectionAssert.assertEqual(results.messages, [


### PR DESCRIPTION
* Use TestScheduler.startScheduler instead of old removed methods
* Fix indentation across test documents
* Update usages of collectionAssert

All of these errors were pointed out by [markdown-doctest](https://github.com/Widdershin/markdown-doctest).