### PR TITLE
fix `delay()` argument formatting

### DIFF
--- a/doc/api/core/operators/delay.md
+++ b/doc/api/core/operators/delay.md
@@ -11,10 +11,12 @@ Time shifts the observable sequence based on a subscription delay and a delay se
 #### Arguments
 
 For delays with an absolute or relative time:
+
 1. `dueTime` *(Date | Number)*: Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) by which to shift the observable sequence.
 2. `[scheduler]` *(`Scheduler`)*: Scheduler to run the delay timers on. If not specified, the default scheduler is used.
 
 For delays with a delay selector function:
+
 1. `[subscriptionDelay]` *(`Observable`)*: Sequence indicating the delay for the subscription to the source.
 2. `delayDurationSelector` *(`Function`)*: Selector function to retrieve a sequence indicating the delay for each given element.
 


### PR DESCRIPTION
so they're rendered as an ordered list instead of a paragraph