### PR TITLE
fixing typescript definition for debounce with a selector function

### DIFF
--- a/ts/core/linq/observable/debounce.ts
+++ b/ts/core/linq/observable/debounce.ts
@@ -15,7 +15,7 @@ module Rx {
         * @param {Function} durationSelector Selector function to retrieve a sequence indicating the throttle duration for each given element.
         * @returns {Observable} The debounced sequence.
         */
-        debounce(debounceDurationSelector: (item: T) => ObservableOrPromise<number>): Observable<T>;
+        debounce(debounceDurationSelector: (item: T) => ObservableOrPromise<any>): Observable<T>;
     }
 }
 


### PR DESCRIPTION
There may have been an oversight or a misunderstanding with how the selector function operates within Rx when this function was originally written. debounce with selector is a little bit complicated because while it's documentation is technically correct, it is also very misleading. The selector function's purpose is not to produce a duration value, but rather a duration from when an observable sequence result is emitted.

What this means is that if you were to do something like `obs.debounce(x => Rx.Observable.return(5000))` you would end up with a result that does not make any sense. This would not debounce for `5000 ms` as you might expect, but rather debounce for (*almost*) `0 ms`. The reason is because the `Rx.Observable.return(...)` produces its next value instantly.

Instead we would want to write something like `obs.debounce(x => Rx.Observable.return(0).delay(5000))` as this would produce the first observable result after `5000 ms` and effectively suppress any results from `obs` for that duration. As you can see here, the actual result from our selector function (`0`) is meaningless as it is the duration before the result is emitted that is important. This is why we do not require that the selector function be generically typed to a `number`, but rather allow `any` type. It would be fairly common for a number to be the generic type since you may often use time based operators to produce your duration observable sequence, but there should be no enforcement of that type.

This behaviour is explained at the [ReactiveX Docs](http://reactivex.io/documentation/operators/debounce.html) for debounce. The marble graphic is the best representation of how the selector operates. Each value emitted from the source observable sequence produces a new duration sequence. when the first result is emitted from the duration sequence the debouce is complete. if a new result is emitted from the source observable before the current duration observable result is emitted (as seen when `#3` is emitted) then the previous value is suppressed (debounced).

This PR aims to resolve #984. While the issue talks about the documentation being incorrect, it is actually correct just easy to misunderstand the documentation's intent. The selector function **is** for duration, but for **observable result** duration, not duration amount.