### PR TITLE
Fixed overloads to avoid catch-all function taking over all overloads.

### DIFF
--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -2855,15 +2855,6 @@ declare module Rx {
          * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
          * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
          */
-        fromCallback<TResult>(func: Function, context: any, selector: Function): (...args: any[]) => Observable<TResult>;
-        /**
-         * Converts a callback function to an observable sequence.
-         *
-         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
-         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
-         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
-         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
-         */
         fromCallback<TResult, T1>(func: (arg1: T1, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1) => Observable<TResult>;
         /**
          * Converts a callback function to an observable sequence.
@@ -2937,17 +2928,18 @@ declare module Rx {
          * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
          */
         fromCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+        /**
+         * Converts a callback function to an observable sequence.
+         *
+         * @param {Function} function Function with a callback as the last parameter to convert to an Observable sequence.
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback to produce a single item to yield on next.
+         * @returns {Function} A function, when executed with the required parameters minus the callback, produces an Observable sequence with a single value of the arguments to the callback as an array.
+         */
+        fromCallback<TResult>(func: Function, context: any, selector: Function): (...args: any[]) => Observable<TResult>;
     }
 
     export interface ObservableStatic {
-        /**
-         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
-         * @param {Function} func The function to call
-         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
-         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
-         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
-         */
-        fromNodeCallback<TResult>(func: Function, context?: any, selector?: Function): (...args: any[]) => Observable<TResult>;
         /**
          * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
          * @param {Function} func The function to call
@@ -3020,6 +3012,14 @@ declare module Rx {
          * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
          */
         fromNodeCallback<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callback: (err: any, result: TResult) => any) => any, context?: any, selector?: Function): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => Observable<TResult>;
+        /**
+         * Converts a Node.js callback style function to an observable sequence.  This must be in function (err, ...) format.
+         * @param {Function} func The function to call
+         * @param {Mixed} [context] The context for the func parameter to be executed.  If not specified, defaults to undefined.
+         * @param {Function} [selector] A selector which takes the arguments from the callback minus the error to produce a single item to yield on next.
+         * @returns {Function} An async function which when applied, returns an observable sequence with the callback arguments as an array.
+         */
+        fromNodeCallback<TResult>(func: Function, context?: any, selector?: Function): (...args: any[]) => Observable<TResult>;
     }
 
     export interface ObservableStatic {


### PR DESCRIPTION
Found from this https://github.com/Microsoft/TypeScript/issues/5453#issuecomment-154259342

Basically users would never get any sort of useful inference because the top overload would always match during resolution. The problem is that any function type is assignable to `Function` (and `Function` itself does't imply 0 parameters).