### PR TITLE
Fix EventPatternDisposable

### DIFF
--- a/src/core/linq/observable/fromeventpattern.js
+++ b/src/core/linq/observable/fromeventpattern.js
@@ -34,6 +34,7 @@
     EventPatternDisposable.prototype.dispose = function () {
       if(!this.isDisposed) {
         isFunction(this._del) && this._del(this._fn, this._ret);
+        this.isDisposed = true;
       }
     };
 


### PR DESCRIPTION
It may be unnecessary because be wrapped by `AutoDetachObserver` and `SingleAssignmentDisposable`.