### PR TITLE
Fix code example typo in fromevent.md

### DIFF
--- a/doc/api/core/operators/fromevent.md
+++ b/doc/api/core/operators/fromevent.md
@@ -49,7 +49,7 @@ var eventEmitter = new EventEmitter();
 var source = Rx.Observable.fromEvent(
   eventEmitter,
   'data',
-  function (foo, bar) { return { foo: bar, bar: bar }; });
+  function (foo, bar) { return { foo: foo, bar: bar }; });
 
 var subscription = source.subscribe(
   function (x) {


### PR DESCRIPTION
I noticed a typo in the code example and fixed it.