### PR TITLE
pipe: don't coerce all values to strings

### DIFF
--- a/src/core/linq/observable/pipe.js
+++ b/src/core/linq/observable/pipe.js
@@ -14,7 +14,7 @@
 
     source.subscribe(
       function (x) {
-        !dest.write(String(x)) && source.pause();
+        !dest.write(x) && source.pause();
       },
       function (err) {
         dest.emit('error', err);


### PR DESCRIPTION
Node.js streams in object mode accept input other than strings, and
streams in object mode don't coerce their values when piping to other
streams. So to be consistent, neither should Observables; Rx users
should map(String) if they need this coercion.