### PR TITLE
multicast: don't reconnect once subject is stopped

### DIFF
--- a/src/core/linq/connectableobservable.js
+++ b/src/core/linq/connectableobservable.js
@@ -55,6 +55,9 @@
 
     ConnectableObservable.prototype.connect = function () {
       if (!this._connection) {
+        if (this._subject.isStopped) {
+          return disposableEmpty;
+        }
         var subscription = this._source.subscribe(this._subject);
         this._connection = new ConnectDisposable(this, subscription);
       }


### PR DESCRIPTION
A stopped subject shouldn't forward any more events, so using it to
subscribe again is pointless at best and a cause of undesirable side
effects at worst.

Fixes Reactive-Extensions/RxJS#1112