### PR TITLE
Fix docs for flatmap file links

### DIFF
--- a/doc/api/core/operators/flatmapfirst.md
+++ b/doc/api/core/operators/flatmapfirst.md
@@ -50,7 +50,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/flatmapfirst.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/flatmapfirst.js)
+- [`/src/core/perf/operators/flatmapfirst.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/flatmapfirst.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)

--- a/doc/api/core/operators/flatmaplatest.md
+++ b/doc/api/core/operators/flatmaplatest.md
@@ -44,7 +44,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/flatmaplatest.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/flatmaplatest.js)
+- [`/src/core/perf/operators/flatmaplatest.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/flatmaplatest.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)

--- a/doc/api/core/operators/flatmapwithmaxconcurrent.md
+++ b/doc/api/core/operators/flatmapwithmaxconcurrent.md
@@ -132,7 +132,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/flatmapwithmaxconcurrent.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/flatmapwithmaxconcurrent.js)
+- [`/src/core/perf/operators/flatmapwithmaxconcurrent.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/flatmapwithmaxconcurrent.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)


### PR DESCRIPTION
`flatMapFirst`, `flatMapLatest`, and `flatMapWithMaxConcurrent` had incorrect/outdated links to their source files. This corrects the link structure from `src/core/linkq/observable/flatmap...js` to `src/core/perf/operators/flatmap...js`