### PR TITLE
Fix docs for flatmap unit test links

### DIFF
--- a/doc/api/core/operators/flatmapfirst.md
+++ b/doc/api/core/operators/flatmapfirst.md
@@ -68,4 +68,4 @@ NuGet Packages:
 - [`RxJS-Experimental`](http://www.nuget.org/packages/RxJS-Experimental/)
 
 Unit Tests:
-- [`/tests/observable/flatmapfirst.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/flatmapfirst.js)
+- None

--- a/doc/api/core/operators/flatmaplatest.md
+++ b/doc/api/core/operators/flatmaplatest.md
@@ -66,4 +66,4 @@ NuGet Packages:
 - [`RxJS-Lite`](http://www.nuget.org/packages/RxJS-Lite/)
 
 Unit Tests:
-- [`/tests/observable/flatmaplatest.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/flatmaplatest.js)
+- None

--- a/doc/api/core/operators/flatmapwithmaxconcurrent.md
+++ b/doc/api/core/operators/flatmapwithmaxconcurrent.md
@@ -147,4 +147,4 @@ NuGet Packages:
 - [`RxJS-Experimental`](http://www.nuget.org/packages/RxJS-Experimental/)
 
 Unit Tests:
-- [`/tests/observable/flatmapwithmaxconcurrent.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/flatmapwithmaxconcurrent.js)
+- None


### PR DESCRIPTION
It doesn't appear that there are unit tests for `flatmapfirst.js`, `flatmaplast.js`, and `flatmapwithmaxconcurrent.js` since these are simply wrappers for constructing a new instance of `FlatMapObservable`.

I've updated these from invalid links to "None". I'm thinking about later introducing some tests to verify the returned instance is the expected one.