### PR TITLE
Add typescript signatures for combineLatest without result selector.

### DIFF
--- a/ts/core/linq/observable/combinelatest.ts
+++ b/ts/core/linq/observable/combinelatest.ts
@@ -81,7 +81,89 @@ module Rx {
         * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
         * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
         */
-        combineLatest<TOther, TResult>(souces: ObservableOrPromise<TOther>[], resultSelector: (...otherValues: TOther[]) => TResult): Observable<TResult>;
+        combineLatest<TOther, TResult>(sources: ObservableOrPromise<TOther>[], resultSelector: (...otherValues: TOther[]) => TResult): Observable<TResult>;
+
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>): Observable<[T, T2]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>): Observable<[T, T2, T3]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>): Observable<[T, T2, T3, T4]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4, T5>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>): Observable<[T, T2, T3, T4, T5]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4, T5, T6>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4, T5, T6, T7>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>): Observable<[T, T2, T3, T4, T5, T6, T7]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4, T5, T6, T7, T8>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>, eighth: ObservableOrPromise<T8>): Observable<[T, T2, T3, T4, T5, T6, T7, T8]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<T, T2, T3, T4, T5, T6, T7, T8, T9>(first: ObservableOrPromise<T>, second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>, eighth: ObservableOrPromise<T8>, ninth: ObservableOrPromise<T9>): Observable<[T, T2, T3, T4, T5, T6, T7, T8, T9]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        *
+        * @example
+        * 1 - obs = Rx.Observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = Rx.Observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing a list of elements of the sources.
+        */
+        combineLatest<TOther>(sources: ObservableOrPromise<TOther>[]): Observable<TOther[]>;
     }
 }
 
@@ -91,7 +173,11 @@ module Rx {
     var so: Rx.Subject<number>;
     var p: Rx.Promise<{ a: string }>;
 
-    var r: Rx.Observable<{ vo: boolean, vio: string, vp: { a: string }, vso: number }> = Rx.Observable.combineLatest(o, io, p, so, (vo, vio, vp, vso) => ({ vo, vio, vp, vso }));
+    var r1: Rx.Observable<{ vo: boolean, vio: string, vp: { a: string }, vso: number }> = Rx.Observable.combineLatest(o, io, p, so, (vo, vio, vp, vso) => ({ vo, vio, vp, vso }));
 
-    var rr : Rx.Observable<number> = Rx.Observable.combineLatest(<any[]>[o, io, so, p], (items) => 5);
+    var r2: Rx.Observable<[boolean, string, { a: string }, number]> = Rx.Observable.combineLatest(o, io, p, so);
+
+    var r3 : Rx.Observable<number> = Rx.Observable.combineLatest(<any[]>[o, io, so, p], (items) => 5);
+
+    var r4: Rx.Observable<any[]> = Rx.Observable.combineLatest(<any[]>[o, io, so, p]);
 });

--- a/ts/core/linq/observable/combinelatestproto.ts
+++ b/ts/core/linq/observable/combinelatestproto.ts
@@ -90,7 +90,98 @@ module Rx {
         * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
         * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
         */
-        combineLatest<TOther, TResult>(souces: ObservableOrPromise<TOther>[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
+        combineLatest<TOther, TResult>(sources: ObservableOrPromise<TOther>[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
+
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2>(second: ObservableOrPromise<T2>): Observable<[T, T2]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>): Observable<[T, T2, T3]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>): Observable<[T, T2, T3, T4]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4, T5>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>): Observable<[T, T2, T3, T4, T5]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4, T5, T6>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4, T5, T6, T7>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>): Observable<[T, T2, T3, T4, T5, T6, T7]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4, T5, T6, T7, T8>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>, eighth: ObservableOrPromise<T8>): Observable<[T, T2, T3, T4, T5, T6, T7, T8]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<T2, T3, T4, T5, T6, T7, T8, T9>(second: ObservableOrPromise<T2>, third: ObservableOrPromise<T3>, fourth: ObservableOrPromise<T4>, fifth: ObservableOrPromise<T5>, sixth: ObservableOrPromise<T6>, seventh: ObservableOrPromise<T7>, eighth: ObservableOrPromise<T8>, ninth: ObservableOrPromise<T9>): Observable<[T, T2, T3, T4, T5, T6, T7, T8, T9]>;
+        /**
+        * Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences or Promises produces an element.
+        * This can be in the form of an argument list of observables or an array.
+        *
+        * @example
+        * 1 - obs = observable.combineLatest(obs1, obs2, obs3, function (o1, o2, o3) { return o1 + o2 + o3; });
+        * 2 - obs = observable.combineLatest([obs1, obs2, obs3], function (o1, o2, o3) { return o1 + o2 + o3; });
+        * @returns {Observable} An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+        */
+        combineLatest<TOther>(sources: ObservableOrPromise<TOther>[]): Observable<TOther[]>;
     }
 }
 
@@ -100,7 +191,11 @@ module Rx {
     var so: Rx.Subject<number>;
     var p: Rx.Promise<{ a: string }>;
 
-    var r: Rx.Observable<{ vo: boolean, vio: string, vp: { a: string }, vso: number }> = o.combineLatest(io, p, so, (vo, vio, vp, vso) => ({ vo, vio, vp, vso }));
+    var r1: Rx.Observable<{ vo: boolean, vio: string, vp: { a: string }, vso: number }> = o.combineLatest(io, p, so, (vo, vio, vp, vso) => ({ vo, vio, vp, vso }));
 
-    var rr : Rx.Observable<number> = o.combineLatest(<any[]>[io, so, p], (v1, items) => 5);
+    var r2 : Rx.Observable<[boolean, string, { a: string }, number]> = o.combineLatest(io, p, so);
+
+    var r3 : Rx.Observable<number> = o.combineLatest(<any[]>[io, so, p], (v1, items) => 5);
+
+    var r4 : Rx.Observable<any[]> = o.combineLatest(<any[]>[io, so, p]);
 });


### PR DESCRIPTION
The final result selector argument for the combineLatest() methods of Rx.Observable (both class and instance) is optional. If it is omitted, the resulting observable yields a list with the elements from each source. This pull request adds TypeScript signatures for the flavour without result selector argument.

For the sake of review I have only committed the primary source files, not generated files like rx.all.d.ts. Right now, running "grunt" on a fresh checkout touches around 60 files. If you want I can add a separate commit updating all generated files before applying this patch.