### PR TITLE
Fix docs for ambproto unit test link

### DIFF
--- a/doc/api/core/operators/ambproto.md
+++ b/doc/api/core/operators/ambproto.md
@@ -55,4 +55,4 @@ NuGet Packages:
 - [`RxJS-Lite`](http://www.nuget.org/packages/RxJS-Lite/)
 
 Unit Tests:
-- [/tests/observable/ambproto.js](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/ambproto.js)
+- [/tests/observable/amb.js](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/amb.js)


### PR DESCRIPTION
Unit test links in the `ambproto` documentation were linking to a 404. This updates the link to what seems like the proper unit test for the module https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/amb.js