### PR TITLE
Fix doc formatting in average documentation

### DIFF
--- a/doc/api/core/operators/average.md
+++ b/doc/api/core/operators/average.md
@@ -63,7 +63,7 @@ File:
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)
 - [`rx.all.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)
-- [rx.aggregates.js](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.aggregates.js)
+- [`rx.aggregates.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.aggregates.js)
 
 Prerequisites:
 - [`rx.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.js) | [`rx.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.compat.js) | [`rx.lite.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.js) | [`rx.lite.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.compat.js)


### PR DESCRIPTION
There was a missing code highlight segment

![screen shot 2016-03-13 at 3 43 44 pm](https://cloud.githubusercontent.com/assets/656630/13730881/7a74c322-e932-11e5-9aa8-c82bb614bffa.png)
