### PR TITLE
fix import rx-lite-compat issue

### DIFF
--- a/modules/rx-lite-compat/package.json
+++ b/modules/rx-lite-compat/package.json
@@ -34,5 +34,5 @@
     "Rx",
     "RxJS"
   ],
-  "main": "rx.lite.js"
+  "main": "rx.lite.compat.js"
 }


### PR DESCRIPTION
Make package.json point to the correct file name