### PR TITLE
Fix doc links for `do` sources

### DIFF
--- a/doc/api/core/operators/do.md
+++ b/doc/api/core/operators/do.md
@@ -80,7 +80,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/do.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/do.js)
+- [`/src/core/perf/operators/tap.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/tap.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)

--- a/doc/api/core/operators/dooncompleted.md
+++ b/doc/api/core/operators/dooncompleted.md
@@ -7,7 +7,7 @@ Invokes an action upon graceful termination of the observable sequence.
 This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.
 
 #### Arguments
-1. `oncompleted` *(`Function`)*: Function to invoke upon graceful termination of the observable sequence. 
+1. `oncompleted` *(`Function`)*: Function to invoke upon graceful termination of the observable sequence.
 2. [`thisArg`] *(Any)*: Object to use as this when executing callback.
 
 #### Returns
@@ -66,7 +66,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/do.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/do.js)
+- [`/src/core/perf/operators/tap.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/tap.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)

--- a/doc/api/core/operators/doonerror.md
+++ b/doc/api/core/operators/doonerror.md
@@ -60,7 +60,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/do.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/do.js)
+- [`/src/core/perf/operators/tap.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/tap.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)

--- a/doc/api/core/operators/doonnext.md
+++ b/doc/api/core/operators/doonnext.md
@@ -70,7 +70,7 @@ var subscription = source.subscribe(
 ### Location
 
 File:
-- [`/src/core/linq/observable/do.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/do.js)
+- [`/src/core/perf/operators/tap.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/tap.js)
 
 Dist:
 - [`rx.all.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.all.js)


### PR DESCRIPTION
The file links for the `do*` docs had linked to a 404. The proper location is [perf/operators/tap.js](https://github.com/Reactive-Extensions/RxJS/blob/8f12f812d497acf639588e90f74d504a9fc801ec/src/core/perf/operators/tap.js) (do's alias)