### PR TITLE
Fix Throttle example

### DIFF
--- a/doc/api/core/operators/throttle.md
+++ b/doc/api/core/operators/throttle.md
@@ -41,7 +41,6 @@ var subscription = source.subscribe(
   });
 
 // => Next: 0
-// => Next: 2
 // => Next: 3
 // => Completed
 ```


### PR DESCRIPTION
Fixes https://github.com/Reactive-Extensions/RxJS/issues/1103 which points out an inaccuracy in the Throttle example.

![screen shot 2016-03-18 at 1 19 08 am](https://cloud.githubusercontent.com/assets/656630/13869129/8b20281a-eca7-11e5-8612-ba65578f3cc8.png)
