### PR TITLE
fix case-sensitive filesystem require('delaySubscription') failure

### DIFF
--- a/src/modular/index.js
+++ b/src/modular/index.js
@@ -68,7 +68,7 @@ Observable.addToPrototype({
   debounce: require('./observable/debounce'),
   defaultIfEmpty: require('./observable/defaultifempty'),
   delay: require('./observable/delay'),
-  delaySubscription: require('./observable/delaySubscription'),
+  delaySubscription: require('./observable/delaysubscription'),
   dematerialize: require('./observable/dematerialize'),
   distinct: require('./observable/distinct'),
   distinctUntilChanged: require('./observable/distinctuntilchanged'),


### PR DESCRIPTION
Currently when I try to do:

```javascript
var Rx = require('@rxjs/rx');
```

It fails as follows:

```
Error: Cannot find module './observable/delaySubscription' from '/Volumes/CASE-SENSITIVE/Project/node_modules/@rxjs/rx'
```

In this commit I just rename the require statement to use the lowercase version of `delaysubscription`.
I have used this implementation because it seems that this approach is used in all other cases:

```javascript
  ...
  asObservable: require('./observable/asobservable'),
  average: require('./observable/average'),
  buffer: require('./observable/buffer'),
  bufferCount: require('./observable/buffercount'),
  bufferTime: require('./observable/buffertime'),
  bufferTimeOrCount: require('./observable/buffertimeorcount'),
  catch: require('./observable/catch'),
  catchHandler: require('./observable/catchhandler'),
  combineLatest: require('./observable/combinelatest'),
  concat: require('./observable/concat'),
  concatAll: require('./observable/concatall'),
  controlled: require('./observable/controlled'),
  count: require('./observable/count'),
  debounce: require('./observable/debounce'),
  defaultIfEmpty: require('./observable/defaultifempty'),
  delay: require('./observable/delay'),
  delaySubscription: require('./observable/delaysubscription'),
  dematerialize: require('./observable/dematerialize'),
  distinct: require('./observable/distinct'),
  distinctUntilChanged: require('./observable/distinctuntilchanged'),
  ...
```