### PR TITLE
Documentation fix

### DIFF
--- a/doc/api/core/operators/publish.md
+++ b/doc/api/core/operators/publish.md
@@ -85,6 +85,7 @@ function createObserver(tag) {
 // => Next: SourceA1
 // => Next: SourceB1
 // => Completed
+// => Completed
 ```
 
 ### Location


### PR DESCRIPTION
"Completed" should be called twice in code sample

```js
/* With publish */
var interval = Rx.Observable.interval(1000);

var source = interval
    .take(2)
    .doAction(function (x) {
        console.log('Side effect');
    });

var published = source.publish();

published.subscribe(createObserver('SourceA'));
published.subscribe(createObserver('SourceB'));

var connection = published.connect();

function createObserver(tag) {
    return Rx.Observer.create(
        function (x) {
            console.log('Next: ' + tag + x);
        },
        function (err) {
            console.log('Error: ' + err);
        },
        function () {
            console.log('Completed');
        });
}

// => Side effect
// => Next: SourceA0
// => Next: SourceB0
// => Side effect
// => Next: SourceA1
// => Next: SourceB1
// => Completed
// => Completed <---- !!! HERE !!!
```