### PR TITLE
Update groupBy and groupByUntil parameter documentation.

### DIFF
--- a/doc/api/core/operators/groupby.md
+++ b/doc/api/core/operators/groupby.md
@@ -1,4 +1,4 @@
-### `Rx.Observable.prototype.groupBy(keySelector, [elementSelector], [comparer])`
+### `Rx.Observable.prototype.groupBy(keySelector, [elementSelector])`
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/groupby.js "View in source")
 
 Groups the elements of an observable sequence according to a specified key selector function and comparer and selects the resulting elements by using a specified function.
@@ -6,7 +6,6 @@ Groups the elements of an observable sequence according to a specified key selec
 #### Arguments
 1. `keySelector` *(`Function`)*: A function to extract the key for each element.
 2. `[elementSelector]` *(`Function`)*: A function to map each source element to an element in an observable group.
-3. `[comparer]` *(`Any`)*: Used to compare objects. If not specified, the default comparer is used.
 
 #### Returns
 *(`Observable`)*: A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.

--- a/doc/api/core/operators/groupbyuntil.md
+++ b/doc/api/core/operators/groupbyuntil.md
@@ -1,4 +1,4 @@
-### `Rx.Observable.prototype.groupByUntil(keySelector, [elementSelector], durationSelector, [comparer])`
+### `Rx.Observable.prototype.groupByUntil(keySelector, [elementSelector], durationSelector)`
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/groupbyuntil.js "View in source")
 
 Groups the elements of an observable sequence according to a specified key selector function and comparer and selects the resulting elements by using a specified function.
@@ -7,7 +7,6 @@ Groups the elements of an observable sequence according to a specified key selec
 1. `keySelector` *(`Function`)*: A function to extract the key for each element.
 2. `[elementSelector]` *(`Function`)*: A function to map each source element to an element in an observable group.
 3. `durationSelector` *(`Function`)*: A function to signal the expiration of a group.
-4. `[comparer]` *(`Any`)*: Used to compare objects. If not specified, the default comparer is used.
 
 #### Returns
 *(`Observable`)*: A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.


### PR DESCRIPTION
As part of #73cbf847512b794a69dddb02bbb4f59ce279c384 the aforementioned methods no longer support comparer parameter.