### PR TITLE
HistoricalScheduler's constructor params are both optional

### DIFF
--- a/doc/api/schedulers/historicalscheduler.md
+++ b/doc/api/schedulers/historicalscheduler.md
@@ -1,7 +1,7 @@
 ### `Rx.HistoricalScheduler` class
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/concurrency/historicalscheduler.js "View in source")
 
-Provides a virtual time scheduler that uses a `Date` for absolute time and time spans for relative time.  This inherits from the `Rx.VirtualTimeScheduler` class.
+Provides a virtual time scheduler that uses an optional `Date` for absolute time and time spans for relative time.  This inherits from the `Rx.VirtualTimeScheduler` class.
 
 ## Usage ##
 


### PR DESCRIPTION
A fix for the documentation and a change to the .d.ts file for HistoricalScheduler as initialClock and comparer are both optional. 
