### PR TITLE
Fix doc of Observable.throw to use exception instead of dueTime

### DIFF
--- a/doc/api/core/operators/throw.md
+++ b/doc/api/core/operators/throw.md
@@ -6,7 +6,7 @@
 Returns an observable sequence that terminates with an exception, using the specified scheduler to send out the single onError message.
 
 ### Arguments
-1. `dueTime` *(`Any`)*: Absolute (specified as a Date object) or relative time (specified as an integer denoting milliseconds) at which to produce the first value.
+1. `exception` *(Error)*: Error the observable sequence terminates with.
 2. `[scheduler=Rx.Scheduler.immediate]` *(`Scheduler`)*: Scheduler to send the exceptional termination call on. If not specified, defaults to the immediate scheduler.
 
 #### Returns


### PR DESCRIPTION
This should fix https://github.com/Reactive-Extensions/RxJS/issues/1130

The first argument is always the error. See unit test of Observable.throw
https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/throw.js
