### PR TITLE
Fix spelling mistake in docs

### DIFF
--- a/doc/api/core/operators/case.md
+++ b/doc/api/core/operators/case.md
@@ -53,7 +53,7 @@ Dist:
 - [`rx.experimental.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.experimental.js)
 
 Prerequisites:
-- If using `rx.expermental.js`
+- If using `rx.experimental.js`
   - [`rx.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.js) | [`rx.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.compat.js) | [`rx.lite.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.js) | [`rx.lite.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.compat.js)
 
 NPM Packages:


### PR DESCRIPTION
s/expermental/experimental/
