### PR TITLE
Update Observable.distinct TS definition

### DIFF
--- a/ts/core/linq/observable/distinct.ts
+++ b/ts/core/linq/observable/distinct.ts
@@ -13,7 +13,7 @@ module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 }
 
@@ -21,5 +21,5 @@ module Rx {
     var o : Rx.Observable<string>;
     o = o.distinct();
     o = o.distinct(x => x.length);
-    o = o.distinct(x => x.length, x => x.toString() + '' + x);
+    o = o.distinct(x => x.length, (x,y) => x.toString() === y.toString());
 });

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -498,7 +498,7 @@ declare module Rx {
         */
         onCompleted(): void;
     }
-    
+
     export interface Observer<T> {
         /**
         * Notifies the observer of a new element in the sequence.
@@ -2095,7 +2095,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -2092,7 +2092,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.d.ts
+++ b/ts/rx.d.ts
@@ -2060,7 +2060,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.es6.d.ts
+++ b/ts/rx.es6.d.ts
@@ -2057,7 +2057,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.lite.extras.d.ts
+++ b/ts/rx.lite.extras.d.ts
@@ -209,7 +209,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.lite.extras.es6.d.ts
+++ b/ts/rx.lite.extras.es6.d.ts
@@ -209,7 +209,7 @@ declare module Rx {
         * @param {Function} [comparer]  Used to compare items in the collection.
         * @returns {Observable} An observable sequence only containing the distinct elements, based on a computed key value, from the source sequence.
         */
-        distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+        distinct<TKey>(keySelector?: (value: T) => TKey, comparer?: _Comparer<TKey, boolean>): Observable<T>;
     }
 
     export interface Observable<T> {


### PR DESCRIPTION
The TypeScript definition for Observable.distinct denoted a
keySelector function as the second parameter, while the code
denotes a comparator function.

Fixes #1319
