### PR TITLE
fix: logic in random function

### DIFF
--- a/examples/animationtest/index.js
+++ b/examples/animationtest/index.js
@@ -1,7 +1,7 @@
 (function () {
 
   function random(low, high) {
-    return Math.floor(Math.random() * (high + 1)) - low;
+    return Math.floor(Math.random() * (high - low + 1)) + low;
   }
 
   function Box(point, parent) {


### PR DESCRIPTION
Fixed logic in the `random()` to work with the implied functionality from the parameter names. The example code isn't currently affected due to `0` being passed as the `low` parameter in all references.