### PR TITLE
export VirtualTimeSchedulers' constructor

### DIFF
--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -4767,6 +4767,7 @@ declare module Rx {
     }
 
     export interface VirtualTimeScheduler<TAbsolute, TRelative> extends IScheduler {
+        clock: TAbsolute;
         /**
          * Adds a relative time value to an absolute time value.
          * @param {Number} absolute Absolute virtual time value.
@@ -4824,7 +4825,30 @@ declare module Rx {
          * @returns {ScheduledItem} The next scheduled item.
          */
         getNext(): internals.ScheduledItem<TAbsolute>;
+
+        /**
+         * Schedules an action to be executed at dueTime.
+         * @param {Mixed} state State passed to the action to be executed.
+         * @param {Any} dueTime Absolute time at which to execute the action.
+         * @param {Function} action Action to be executed.
+         * @returns {Disposable} The disposable object used to cancel the scheduled action (best effort).
+         */
+        scheduleAbsolute(
+            state: any,
+            dueTime: TAbsolute,
+            action: (scheduler: VirtualTimeScheduler, state: any) => any
+        ): SingleAssignmentDisposable;
     }
+
+    export var VirtualTimeScheduler: {
+        /**
+         * Creates a new historical scheduler with the specified initial clock value.
+         * @constructor
+         * @param {Any} initialClock Initial value for the clock.
+         * @param {Function} comparer Comparer to determine causality of events based on absolute time.
+         */
+        new <TAbsolute, TRelative>(initialClock: TAbsolute, comparer: _Comparer<TAbsolute, TRelative>): VirtualTimeScheduler<TAbsolute, TRelative>;
+    };
 
     export interface HistoricalScheduler extends VirtualTimeScheduler<number, number> {
     }

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -4836,7 +4836,7 @@ declare module Rx {
         scheduleAbsolute(
             state: any,
             dueTime: TAbsolute,
-            action: (scheduler: VirtualTimeScheduler, state: any) => any
+            action: (scheduler: VirtualTimeScheduler<TAbsolute, TRelative>, state: any) => any
         ): SingleAssignmentDisposable;
     }
 

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -4858,7 +4858,7 @@ declare module Rx {
         scheduleAbsolute(
             state: any,
             dueTime: TAbsolute,
-            action: (scheduler: VirtualTimeScheduler, state: any) => any
+            action: (scheduler: VirtualTimeScheduler<TAbsolute, TRelative>, state: any) => any
         ): SingleAssignmentDisposable;
     }
 

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -4789,6 +4789,7 @@ declare module Rx {
     }
 
     export interface VirtualTimeScheduler<TAbsolute, TRelative> extends IScheduler {
+        clock: TAbsolute;
         /**
          * Adds a relative time value to an absolute time value.
          * @param {Number} absolute Absolute virtual time value.
@@ -4846,7 +4847,30 @@ declare module Rx {
          * @returns {ScheduledItem} The next scheduled item.
          */
         getNext(): internals.ScheduledItem<TAbsolute>;
+
+        /**
+         * Schedules an action to be executed at dueTime.
+         * @param {Mixed} state State passed to the action to be executed.
+         * @param {Any} dueTime Absolute time at which to execute the action.
+         * @param {Function} action Action to be executed.
+         * @returns {Disposable} The disposable object used to cancel the scheduled action (best effort).
+         */
+        scheduleAbsolute(
+            state: any,
+            dueTime: TAbsolute,
+            action: (scheduler: VirtualTimeScheduler, state: any) => any
+        ): SingleAssignmentDisposable;
     }
+
+    export var VirtualTimeScheduler: {
+        /**
+         * Creates a new historical scheduler with the specified initial clock value.
+         * @constructor
+         * @param {Any} initialClock Initial value for the clock.
+         * @param {Function} comparer Comparer to determine causality of events based on absolute time.
+         */
+        new <TAbsolute, TRelative>(initialClock: TAbsolute, comparer: _Comparer<TAbsolute, TRelative>): VirtualTimeScheduler<TAbsolute, TRelative>;
+    };
 
     export interface HistoricalScheduler extends VirtualTimeScheduler<number, number> {
     }

--- a/ts/rx.virtualtime.d.ts
+++ b/ts/rx.virtualtime.d.ts
@@ -60,6 +60,16 @@ declare module Rx {
         getNext(): internals.ScheduledItem<TAbsolute>;
     }
 
+    export var VirtualTimeScheduler: {
+        /**
+         * Creates a new historical scheduler with the specified initial clock value.
+         * @constructor
+         * @param {Any} initialClock Initial value for the clock.
+         * @param {Function} comparer Comparer to determine causality of events based on absolute time.
+         */
+        new <TAbsolute, TRelative>(initialClock: TAbsolute, comparer: _Comparer<TAbsolute, TRelative>): VirtualTimeScheduler<TAbsolute, TRelative>;
+    };
+
     export interface HistoricalScheduler extends VirtualTimeScheduler<number, number> {
     }
 

--- a/ts/rx.virtualtime.d.ts
+++ b/ts/rx.virtualtime.d.ts
@@ -1,6 +1,7 @@
 declare module Rx {
 
     export interface VirtualTimeScheduler<TAbsolute, TRelative> extends IScheduler {
+        clock: TAbsolute;
         /**
          * Adds a relative time value to an absolute time value.
          * @param {Number} absolute Absolute virtual time value.
@@ -58,6 +59,19 @@ declare module Rx {
          * @returns {ScheduledItem} The next scheduled item.
          */
         getNext(): internals.ScheduledItem<TAbsolute>;
+
+        /**
+         * Schedules an action to be executed at dueTime.
+         * @param {Mixed} state State passed to the action to be executed.
+         * @param {Any} dueTime Absolute time at which to execute the action.
+         * @param {Function} action Action to be executed.
+         * @returns {Disposable} The disposable object used to cancel the scheduled action (best effort).
+         */
+        scheduleAbsolute(
+            state: any,
+            dueTime: TAbsolute,
+            action: (scheduler: VirtualTimeScheduler, state: any) => any
+        ): SingleAssignmentDisposable;
     }
 
     export var VirtualTimeScheduler: {

--- a/ts/rx.virtualtime.d.ts
+++ b/ts/rx.virtualtime.d.ts
@@ -70,7 +70,7 @@ declare module Rx {
         scheduleAbsolute(
             state: any,
             dueTime: TAbsolute,
-            action: (scheduler: VirtualTimeScheduler, state: any) => any
+            action: (scheduler: VirtualTimeScheduler<TAbsolute, TRelative>, state: any) => any
         ): SingleAssignmentDisposable;
     }
 


### PR DESCRIPTION
Since VirtualTimeScheduler is exposed by library itself it should be exposed by typings.
I not sure whether changes will be included in `rx.all` automagically (haven't found such script).