### PR TITLE
Fix typo (Diposable -> Disposable)

### DIFF
--- a/dist/rx.all.compat.js
+++ b/dist/rx.all.compat.js
@@ -2379,7 +2379,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.all.js
+++ b/dist/rx.all.js
@@ -2028,7 +2028,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.compat.js
+++ b/dist/rx.compat.js
@@ -2379,7 +2379,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.core.js
+++ b/dist/rx.core.js
@@ -1154,7 +1154,7 @@ var
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.js
+++ b/dist/rx.js
@@ -2028,7 +2028,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.lite.compat.js
+++ b/dist/rx.lite.compat.js
@@ -2089,7 +2089,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/dist/rx.lite.js
+++ b/dist/rx.lite.js
@@ -1740,7 +1740,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/modules/rx-core/rx.core.js
+++ b/modules/rx-core/rx.core.js
@@ -1154,7 +1154,7 @@ var
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/modules/rx-lite-compat/rx.lite.compat.js
+++ b/modules/rx-lite-compat/rx.lite.compat.js
@@ -2089,7 +2089,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/modules/rx-lite/rx.lite.js
+++ b/modules/rx-lite/rx.lite.js
@@ -1740,7 +1740,7 @@ var isEqual = Rx.internals.isEqual = function (value, other) {
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/src/core/observable.js
+++ b/src/core/observable.js
@@ -42,7 +42,7 @@
      *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (oOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/src/modular/dist/rx.all.js
+++ b/src/modular/dist/rx.all.js
@@ -557,7 +557,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
 	 *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
 	 *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-	 *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+	 *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
 	 */
 	Observable.prototype.subscribe = function (oOrOnNext, onError, onCompleted) {
 	  return this._subscribe(typeof oOrOnNext === 'object' ? oOrOnNext : create(oOrOnNext, onError, onCompleted));

--- a/src/modular/dist/rx.lite.js
+++ b/src/modular/dist/rx.lite.js
@@ -451,7 +451,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
 	 *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
 	 *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-	 *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+	 *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
 	 */
 	Observable.prototype.subscribe = function (oOrOnNext, onError, onCompleted) {
 	  return this._subscribe(typeof oOrOnNext === 'object' ? oOrOnNext : create(oOrOnNext, onError, onCompleted));

--- a/src/modular/observable.js
+++ b/src/modular/observable.js
@@ -19,7 +19,7 @@ Observable.isObservable = function (o) {
  *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
  *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
  *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
- *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+ *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
  */
 Observable.prototype.subscribe = function (oOrOnNext, onError, onCompleted) {
   return this._subscribe(typeof oOrOnNext === 'object' ?

--- a/tests/perf/old/rx.all.compat.js
+++ b/tests/perf/old/rx.all.compat.js
@@ -2307,7 +2307,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/tests/perf/old/rx.all.js
+++ b/tests/perf/old/rx.all.js
@@ -2118,7 +2118,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/tests/perf/old/rx.compat.js
+++ b/tests/perf/old/rx.compat.js
@@ -2307,7 +2307,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/tests/perf/old/rx.js
+++ b/tests/perf/old/rx.js
@@ -2118,7 +2118,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/tests/perf/old/rx.lite.compat.js
+++ b/tests/perf/old/rx.lite.compat.js
@@ -2004,7 +2004,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/tests/perf/old/rx.lite.js
+++ b/tests/perf/old/rx.lite.js
@@ -1815,7 +1815,7 @@
      *  @param {Mixed} [observerOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
      *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
      *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-     *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+     *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
      */
     observableProto.subscribe = observableProto.forEach = function (observerOrOnNext, onError, onCompleted) {
       return this._subscribe(typeof observerOrOnNext === 'object' ?

--- a/ts/core/observable.ts
+++ b/ts/core/observable.ts
@@ -37,7 +37,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -45,7 +45,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -56,7 +56,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -64,7 +64,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -95,7 +95,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -104,7 +104,7 @@ module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -138,7 +138,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -146,7 +146,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -157,7 +157,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -165,7 +165,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -196,7 +196,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -205,7 +205,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -135,7 +135,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -143,7 +143,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -154,7 +154,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -162,7 +162,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -193,7 +193,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -202,7 +202,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.core.d.ts
+++ b/ts/rx.core.d.ts
@@ -108,7 +108,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -116,7 +116,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -127,7 +127,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -135,7 +135,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -166,7 +166,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -175,7 +175,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.core.es6.d.ts
+++ b/ts/rx.core.es6.d.ts
@@ -105,7 +105,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -113,7 +113,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -124,7 +124,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -132,7 +132,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -163,7 +163,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -172,7 +172,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.d.ts
+++ b/ts/rx.d.ts
@@ -138,7 +138,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -146,7 +146,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -157,7 +157,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -165,7 +165,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -196,7 +196,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -205,7 +205,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.es6.d.ts
+++ b/ts/rx.es6.d.ts
@@ -135,7 +135,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -143,7 +143,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -154,7 +154,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -162,7 +162,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -193,7 +193,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -202,7 +202,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.lite.d.ts
+++ b/ts/rx.lite.d.ts
@@ -138,7 +138,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -146,7 +146,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -157,7 +157,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -165,7 +165,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -196,7 +196,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -205,7 +205,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }

--- a/ts/rx.lite.es6.d.ts
+++ b/ts/rx.lite.es6.d.ts
@@ -135,7 +135,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -143,7 +143,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }
@@ -154,7 +154,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(observer: IObserver<T>): IDisposable;
         /**
@@ -162,7 +162,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
 
@@ -193,7 +193,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(observer: IObserver<T>): IDisposable;
 
@@ -202,7 +202,7 @@ declare module Rx {
         *  @param {Mixed} [oOrOnNext] The object that is to receive notifications or an action to invoke for each element in the observable sequence.
         *  @param {Function} [onError] Action to invoke upon exceptional termination of the observable sequence.
         *  @param {Function} [onCompleted] Action to invoke upon graceful termination of the observable sequence.
-        *  @returns {Diposable} A disposable handling the subscriptions and unsubscriptions.
+        *  @returns {Disposable} A disposable handling the subscriptions and unsubscriptions.
         */
         forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
     }


### PR DESCRIPTION
For some reason couple of files have same typo in doc strings, they describe return value as type of `Diposable` while correct should be `Disposable`.