### PR TITLE
Fix typo

### DIFF
--- a/doc/api/core/operators/for.md
+++ b/doc/api/core/operators/for.md
@@ -80,7 +80,7 @@ Dist:
 - [`rx.experimental.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.experimental.js)
 
 Prerequisites:
-- If using `rx.expermental.js`
+- If using `rx.experimental.js`
   - [`rx.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.js) | [`rx.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.compat.js) | [`rx.lite.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.js) | [`rx.lite.compat.js`](https://github.com/Reactive-Extensions/RxJS/blob/master/dist/rx.lite.compat.js)
 
 NPM Packages:


### PR DESCRIPTION
Fixed a missing `i` in `rx.experimental.js` in the doc