### PR TITLE
Fix doc/readme.md

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -33,11 +33,11 @@ To put it more concretely, if you know how to program against Arrays using the A
  </thead>
  <tbody>
   <tr><td><pre><code>getDataFromLocalMemory()
-  .filter (s => s != null)
+  .filter(s => s != null)
   .map(s => s + 'transformed')
   .forEach(s => console.log(\`next => ${s}\`))</code></pre></td>
   <td><pre><code>getDataFromNetwork()
-  .filter (s => s != null)
+  .filter(s => s != null)
   .map(s => s + 'transformed')
   .subscribe(s => console.log(\`next => ${s}\`))</code></pre></td></tr>
  </tbody>


### PR DESCRIPTION
This removes a nonexistent space in the high-order function chain example.