### PR TITLE
Fix to 'and' documentation

### DIFF
--- a/doc/api/core/operators/and.md
+++ b/doc/api/core/operators/and.md
@@ -1,7 +1,7 @@
 ### `Rx.Observable.prototype.and(rightSource)`
 [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/and.js "View in source")
 
-Propagates the observable sequence that reacts first.
+Creates a pattern that matches when both observable sequences have an available value.
 
 #### Arguments
 1. `right` *(`Observable`)*: Observable sequence to match with the current sequence.


### PR DESCRIPTION
Fix to 'and' documentation summary that looked like it was copy-pasted from 'amb'