### PR TITLE
Ignore ts directory to decrease npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ src/
 CHANGELOG.*
 Gruntfile.js
 travis.sh
+ts


### PR DESCRIPTION
By ignoring `ts` the npm package size goes down from 10.4MB to 5.4MB.

Reproducible by running `npm pack`, extracting and looking at the directory size.