### PR TITLE
Now that RX.js 5 isn't in beta, update this readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
 
 # The Reactive Extensions for JavaScript (RxJS) <sup>4.0</sup>... #
 
-Note: RxJS v5 beta is being developed at https://github.com/ReactiveX/rxjs.
+Note: RxJS v5 is out and available now at https://github.com/ReactiveX/rxjs.
 
 *...is a set of libraries to compose asynchronous and event-based programs using observable collections and [Array#extras](http://blogs.msdn.com/b/ie/archive/2010/12/13/ecmascript-5-part-2-array-extras.aspx) style composition in JavaScript*
 


### PR DESCRIPTION
Before it suggested that RX.js 5 was in beta which isn't the case anymore.