### PR TITLE
Add materialize.md to documentation list

### DIFF
--- a/doc/api/core/observable.md
+++ b/doc/api/core/observable.md
@@ -113,6 +113,7 @@ The Observer and Observable interfaces provide a generalized mechanism for push-
 - [`let`](operators/let.md)
 - [`manySelect`](operators/manyselect.md)
 - [`map`](operators/select.md)
+- [`materialize`](operators/materialize.md)
 - [`max`](operators/max.md)
 - [`maxBy`](operators/maxby.md)
 - [`merge`](operators/mergeproto.md)


### PR DESCRIPTION
Issue #849 (https://github.com/Reactive-Extensions/RxJS/issues/849) was closed, but the created documentation for it is currently not available via the observable documentation.