### PR TITLE
Add clarification to custom comparer example

### DIFF
--- a/doc/api/core/operators/distinctuntilchanged.md
+++ b/doc/api/core/operators/distinctuntilchanged.md
@@ -50,7 +50,7 @@ var subscription = source.subscribe(
 // => Next: { value: 24 }
 // => Completed
 
-/* With comparer */
+/* With custom comparer, which returns false when values ARE equal */
 var source = Rx.Observable.of({value: 42}, {value: 42}, {value: 24}, {value: 24})
   .distinctUntilChanged(function (x) { return x.value; }, function (a,b) { return a !== b; });
 


### PR DESCRIPTION
Several open pull requests seem to not have noticed that the custom comparer function here is inverted, and hence the output listed (42, 42) is correct. Hopefully this quick comment change will make it clear that this is not a mistake.