### PR TITLE
Rename license type to proper SPDX format for Apache-2.0 licences

### DIFF
--- a/modules/rx-core-binding/package.json
+++ b/modules/rx-core-binding/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-core-testing/package.json
+++ b/modules/rx-core-testing/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-core/package.json
+++ b/modules/rx-core/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-aggregates-compat/package.json
+++ b/modules/rx-lite-aggregates-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-aggregates/package.json
+++ b/modules/rx-lite-aggregates/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-async-compat/package.json
+++ b/modules/rx-lite-async-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-async/package.json
+++ b/modules/rx-lite-async/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-backpressure-compat/package.json
+++ b/modules/rx-lite-backpressure-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-backpressure/package.json
+++ b/modules/rx-lite-backpressure/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-coincidence-compat/package.json
+++ b/modules/rx-lite-coincidence-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-coincidence/package.json
+++ b/modules/rx-lite-coincidence/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-compat/package.json
+++ b/modules/rx-lite-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-experimental-compat/package.json
+++ b/modules/rx-lite-experimental-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-experimental/package.json
+++ b/modules/rx-lite-experimental/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-extras-compat/package.json
+++ b/modules/rx-lite-extras-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-extras/package.json
+++ b/modules/rx-lite-extras/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-joinpatterns-compat/package.json
+++ b/modules/rx-lite-joinpatterns-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-joinpatterns/package.json
+++ b/modules/rx-lite-joinpatterns/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-testing-compat/package.json
+++ b/modules/rx-lite-testing-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-testing/package.json
+++ b/modules/rx-lite-testing/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-time-compat/package.json
+++ b/modules/rx-lite-time-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-time/package.json
+++ b/modules/rx-lite-time/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-virtualtime-compat/package.json
+++ b/modules/rx-lite-virtualtime-compat/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite-virtualtime/package.json
+++ b/modules/rx-lite-virtualtime/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],

--- a/modules/rx-lite/package.json
+++ b/modules/rx-lite/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": [
     {
-      "type": "Apache License, Version 2.0",
+      "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],


### PR DESCRIPTION
The licenses stated were not following the licences type format (SPDX identifier format) specified in the npm package documentation. This causes issues with a few other npm packages which are used to check licence information of modules and module dependencies. I've filed [an issue](https://github.com/Reactive-Extensions/RxJS/issues/1518) for this but thought it might be quicker to simply make a PR