### PR TITLE
fix a bug in `manySelect`

### DIFF
--- a/src/core/linq/observable/manyselect.js
+++ b/src/core/linq/observable/manyselect.js
@@ -14,7 +14,7 @@
         .map(function (x) {
           var curr = new ChainObservable(x);
 
-          chain && chain.onNext(x);
+          chain && chain.onNext(curr);
           chain = curr;
 
           return curr;


### PR DESCRIPTION
See the corresponding issue/PR in [RxPy](https://github.com/ReactiveX/RxPY/pull/217). This should fix #1358 as well.

I'm not a JS developer and don't use this library, but I thought I would contribute at least this much so y'all are aware. In the RxPy PR, I also updated the test coverage so that the bug in master was made apparent, which we should do here as well.