### PR TITLE
🐐 Replace joins for loop with a .find array opt.

### DIFF
--- a/src/core/joins/activeplan.js
+++ b/src/core/joins/activeplan.js
@@ -15,12 +15,11 @@
 
   ActivePlan.prototype.match = function () {
     var i, len, hasValues = true;
-    for (i = 0, len = this.joinObserverArray.length; i < len; i++) {
-      if (this.joinObserverArray[i].queue.length === 0) {
-        hasValues = false;
-        break;
-      }
-    }
+    
+    hasValues = this.joinedObserverArray.find(function(v) {
+      return v.queue.length === 0;
+    }) === undefined;
+    
     if (hasValues) {
       var firstValues = [],
           isCompleted = false;


### PR DESCRIPTION
The intent of the for loop in this case was to find (if present) an entity in the joinObserveArray who's queue has no elements, when that element was found hasValues was set to false and the for loop was exited.

The semantics of this code can be replaced with a more "idiomatic" find operation which will do the following:

1. loop over each element until an element is found
2. return the found element which can be used to set hasValues to false;

---

Thanks so much for your time reviewing this PR and have a great day!