### PR TITLE
Add pluck keyof type for prop #1530

### DIFF
--- a/ts/core/linq/observable/pluck.ts
+++ b/ts/core/linq/observable/pluck.ts
@@ -7,8 +7,8 @@ module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 }
 

--- a/ts/rx.all.d.ts
+++ b/ts/rx.all.d.ts
@@ -2362,8 +2362,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
 

--- a/ts/rx.all.es6.d.ts
+++ b/ts/rx.all.es6.d.ts
@@ -2357,8 +2357,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
 

--- a/ts/rx.d.ts
+++ b/ts/rx.d.ts
@@ -2260,8 +2260,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.es6.d.ts
+++ b/ts/rx.es6.d.ts
@@ -2257,8 +2257,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
     export interface Observable<T> {

--- a/ts/rx.lite.d.ts
+++ b/ts/rx.lite.d.ts
@@ -2014,8 +2014,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
 

--- a/ts/rx.lite.es6.d.ts
+++ b/ts/rx.lite.es6.d.ts
@@ -2011,8 +2011,8 @@ declare module Rx {
         * @param {Arguments} arguments The nested properties to pluck.
         * @returns {Observable} Returns a new Observable sequence of property values.
         */
-        pluck<TResult>(prop: string): Observable<TResult>;
-        pluck<TResult>(...props: string[]): Observable<TResult>;
+        pluck<TResult, K extends keyof TResult>(prop: K): Observable<TResult[K]>;
+        pluck<TResult, K extends keyof TResult>(...props: K[]): Observable<TResult[K]>;
     }
 
 


### PR DESCRIPTION
Why don't we use typescript's keyof operator instead of just string in pluck operator?
I'm saying we can convert pluck types from
```ts
pluck<T, R>(props: string[]): R {}
```
To
```ts
pluck<T, K extends keyof T>(props: K[]): T[K] {}
```
This stuff gives us an error on compilation phase for the following code
```ts
Rx.Observable.of({
    a: 1,
    b: 2,
}).pluck('c')
```